### PR TITLE
Generate API reference using sphinx.ext.autodoc

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -206,3 +206,38 @@ not a solution.
         with picobox.push(picobox.Box()) as box:
             box.put('foo', 42)
             assert spam() == 42
+
+
+API reference
+-------------
+
+.. module:: picobox
+
+Box
+```
+
+.. autoclass:: Box
+    :members: put, get, pass_
+
+Scopes
+``````
+
+.. autoclass:: Scope
+    :members: set, get
+
+.. autodata:: singleton
+    :annotation:
+
+.. autodata:: threadlocal
+    :annotation:
+
+.. autodata:: noscope
+    :annotation:
+
+Stacked API
+```````````
+
+.. autofunction:: push
+.. autofunction:: put
+.. autofunction:: get
+.. autofunction:: pass_

--- a/picobox/_scopes.py
+++ b/picobox/_scopes.py
@@ -5,17 +5,31 @@ import threading
 
 
 class Scope(metaclass=abc.ABCMeta):
+    """Scope is an execution context based storage interface.
+
+    Execution context is a mechanism of storing and accessing data bound to a
+    logical thread of execution. Thus, one may consider processes, threads,
+    greenlets, coroutines, Flask requests to be examples of a logical thread.
+
+    The interface provides just two methods:
+
+     * :meth:`.set` - set execution context item
+     * :meth:`.get` - get execution context item
+
+    See corresponding methods for details below.
+    """
 
     @abc.abstractmethod
     def set(self, key, value):
-        pass
+        """Bind `value` to `key` in current execution context."""
 
     @abc.abstractmethod
     def get(self, key):
-        pass
+        """Get `value` by `key` for current execution context."""
 
 
 class singleton(Scope):
+    """Share instances across application."""
 
     def __init__(self):
         self._store = {}
@@ -28,6 +42,7 @@ class singleton(Scope):
 
 
 class threadlocal(Scope):
+    """Share instances across the same thread."""
 
     def __init__(self):
         self._store = threading.local()
@@ -44,6 +59,7 @@ class threadlocal(Scope):
 
 
 class noscope(Scope):
+    """Do not share instances, create them each time on demand."""
 
     def set(self, key, value):
         pass

--- a/picobox/_stack.py
+++ b/picobox/_stack.py
@@ -30,6 +30,32 @@ _topbox = _topbox()
 
 
 class push:
+    """Context manager to push a :class:`Box` instance to the top of the stack.
+
+    The box on the top is used by :func:`put`, :func:`get` and :func:`pass_`
+    functions (not methods) and together they define a so called Picobox's
+    stacked interface. The idea behind stacked interface is to provide a way
+    to easily switch DI containers (boxes) without changing injections.
+
+    Here's a minimal example of how push can be used::
+
+        import picobox
+
+        @picobox.pass_('magic')
+        def do(magic):
+            return magic + 1
+
+        foobox = picobox.Box()
+        foobox.put('magic', 42)
+
+        barbox = picobox.Box()
+        barbox.put('magic', 13)
+
+        with picobox.push(foobox):
+            with picobox.push(barbox):
+                assert do() == 14
+            assert do() == 43
+    """
 
     def __init__(self, box):
         self._lock = threading.Lock()
@@ -61,14 +87,17 @@ def _wraps(method):
 
 @_wraps(Box.put)
 def put(*args, **kwargs):
+    """The same as :meth:`Box.put` but for a box at the top of the stack."""
     return Box.put(_topbox, *args, **kwargs)
 
 
 @_wraps(Box.get)
 def get(*args, **kwargs):
+    """The same as :meth:`Box.get` but for a box at the top of the stack."""
     return Box.get(_topbox, *args, **kwargs)
 
 
 @_wraps(Box.pass_)
 def pass_(*args, **kwargs):
+    """The same as :meth:`Box.pass_` but for a box at the top of the stack."""
     return Box.pass_(_topbox, *args, **kwargs)


### PR DESCRIPTION
sphinx.ext.autodoc uses docstrings to generate an API reference.
In order to provide meaningful information there, we were forced
to write meaningful docstrings for public methods which is done
in this very commit.