### PR TITLE
Set proper Git root for use_scm_version battery

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,9 @@ setuptools.setup(
     author='Ihor Kalnytskyi',
     author_email='ihor@kalnytskyi.com',
     packages=setuptools.find_packages(exclude=['docs', 'tests*']),
-    use_scm_version=True,
+    use_scm_version={
+        'root': here,
+    },
     setup_requires=[
         'setuptools_scm',
     ],


### PR DESCRIPTION
When use_scm_version=True current working directory is assumed as Git
root. This is completely wrong assumption that breaks the following
lines:

 $ cd /tmp
 $ python ~/path/to/picobox/setup.py sdist

which might be a valid case on some CI systems. Instead of relying on
CWD pointed to Git root, let's explicitly say that Git root is where
setup.py located.