### PR TITLE
Use RLock to enable injection on injection case

### DIFF
--- a/picobox/_box.py
+++ b/picobox/_box.py
@@ -49,7 +49,7 @@ class Box(object):
     def __init__(self):
         self._store = {}
         self._scope_instances = {}
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
 
     def put(self, key, value=_missing, factory=_missing, scope=_missing):
         """Define a dependency (aka service) within the box instance.

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -97,6 +97,19 @@ def test_box_put_factory_custom_scope():
     assert len(set(map(id, objects))) == 2
 
 
+def test_box_put_factory_dependency():
+    testbox = picobox.Box()
+
+    @testbox.pass_('a')
+    def fn(a):
+        return a + 1
+
+    testbox.put('a', 13)
+    testbox.put('b', factory=fn)
+
+    assert testbox.get('b') == 14
+
+
 def test_box_put_value_and_factory():
     testbox = picobox.Box()
 

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -68,6 +68,20 @@ def test_box_put_factory_singleton_scope():
     assert len(set(map(id, objects))) == 1
 
 
+def test_box_put_factory_dependency():
+    testbox = picobox.Box()
+
+    @picobox.pass_('a')
+    def fn(a):
+        return a + 1
+
+    with picobox.push(testbox):
+        picobox.put('a', 13)
+        picobox.put('b', factory=fn)
+
+        assert picobox.get('b') == 14
+
+
 def test_box_put_value_and_factory():
     testbox = picobox.Box()
 


### PR DESCRIPTION
Injection on injection case is the case when trying to resolve
dependency A, we need to resolve dependency B (or when A depends on B).
In this case we are likely to recursively call .get() method from the
same thread and there's nothing wrong with it and locking must be
relaxed.