### PR TITLE
Add .coverage.* to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 .tox/
 .coverage
+.coverage.*
 .cache
 nosetests.xml
 coverage.xml


### PR DESCRIPTION
Coverage.py produces multiple .coverage files when ran in parallel mode,
and we use this mode as a workaround to normalize (merge) paths since
7a61db414081f781e30113e32d2341919a17c523.