### PR TITLE
Add 'Release Notes' section to docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -241,3 +241,14 @@ Stacked API
 .. autofunction:: put
 .. autofunction:: get
 .. autofunction:: pass_
+
+
+Release Notes
+-------------
+
+1.0.0
+`````
+
+Released on Nov 25, 2017.
+
+* First public release with initial bunch of features.


### PR DESCRIPTION
Because there are couple of new features I want to implement, and the
only known way to deliver information about new goodies is to use
release notes section that enlists all noticeable changes.