### PR TITLE
Add ChainBox container

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -217,7 +217,13 @@ Box
 ```
 
 .. autoclass:: Box
-    :members: put, get, pass_
+    :members:
+
+ChainBox
+````````
+
+.. autoclass:: ChainBox
+    :members:
 
 Scopes
 ``````
@@ -245,6 +251,10 @@ Stacked API
 
 Release Notes
 -------------
+
+* New ``ChainBox`` class that can be used similar to ``ChainMap`` but for
+  boxes. This basically means from now on you can group few boxes into one
+  view, and use that view to look up dependencies.
 
 1.0.0
 `````

--- a/src/picobox/__init__.py
+++ b/src/picobox/__init__.py
@@ -1,12 +1,13 @@
 """Dependency injection framework designed with Python in mind."""
 
-from ._box import Box
+from ._box import Box, ChainBox
 from ._scopes import Scope, singleton, threadlocal, noscope
 from ._stack import push, put, get, pass_
 
 
 __all__ = [
     'Box',
+    'ChainBox',
 
     'Scope',
     'singleton',

--- a/src/picobox/_stack.py
+++ b/src/picobox/_stack.py
@@ -88,13 +88,13 @@ def _wraps(method):
 @_wraps(Box.put)
 def put(*args, **kwargs):
     """The same as :meth:`Box.put` but for a box at the top of the stack."""
-    return Box.put(_topbox, *args, **kwargs)
+    return _topbox.put(*args, **kwargs)
 
 
 @_wraps(Box.get)
 def get(*args, **kwargs):
     """The same as :meth:`Box.get` but for a box at the top of the stack."""
-    return Box.get(_topbox, *args, **kwargs)
+    return _topbox.get(*args, **kwargs)
 
 
 @_wraps(Box.pass_)


### PR DESCRIPTION
ChainBox for boxes is essentially the same as ChainMap for mappings. It
mimics Box interface and hence can substitute one while provides a way
to lookup for a dependency in underlying boxes. While being useful on
its own, ChainBox is essential part of chaining boxes on the stack which
is not implemented yet but will be done pretty soon.