### PR TITLE
Sort autodoc members by appearance in sources

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,7 @@ master_doc = 'index'
 exclude_patterns = ['_build', '_themes']
 pygments_style = 'sphinx'
 intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
+autodoc_member_order = 'bysource'
 
 # -- HTML output
 html_use_index = False


### PR DESCRIPTION
Picobox defines classes and class members in the order that would have
best benefit for reading. By default, Sphinx's autodoc sorts members in
alphabetical order while it would be better to keep order defined in
sources.