### PR TITLE
Rename push() into pushpop()

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -185,10 +185,10 @@ general methods that will be applied to latest active box instance.
     box_b = picobox.Box()
     box_b.put('foo', 42)
 
-    with picobox.push(box_a):
+    with picobox.pushpop(box_a):
         print(spam())               # 13
 
-        with picobox.push(box_b):
+        with picobox.pushpop(box_b):
             print(spam())           # 42
 
         print(spam())               # 13
@@ -214,8 +214,8 @@ missed lookups will be proxied to the box one level down the stack.
     box_b = picobox.Box()
     box_b.put('bar', 0)
 
-    with picobox.push(box_a):
-        with picobox.push(box_b, chain=True):
+    with picobox.pushpop(box_a):
+        with picobox.pushpop(box_b, chain=True):
             print(spam())           # 13
 
 The stack interface is recommended way to use Picobox because it allows to
@@ -226,7 +226,7 @@ not a solution.
 .. code:: python
 
     def test_spam():
-        with picobox.push(picobox.Box(), chain=True) as box:
+        with picobox.pushpop(picobox.Box(), chain=True) as box:
             box.put('foo', 42)
             assert spam() == 42
 
@@ -267,6 +267,7 @@ Stacked API
 ```````````
 
 .. autofunction:: push
+.. autofunction:: pushpop
 .. autofunction:: put
 .. autofunction:: get
 .. autofunction:: pass_
@@ -280,6 +281,9 @@ Release Notes
     Picobox follows `Semantic Versioning <https://semver.org>`_ which means
     backward incompatible changes will be released along with bumping major
     version component.
+
+* ``push()`` context manager has been renamed into ``pushpop()``. This is a
+  breaking change though ``push()`` will work as before till Picobox 2.0.
 
 1.1.0
 `````

--- a/examples/cascade/example.py
+++ b/examples/cascade/example.py
@@ -14,7 +14,7 @@ def rice(secret):
     print(secret)
 
 
-with picobox.push(picobox.Box()) as box:
+with picobox.pushpop(picobox.Box()) as box:
     box.put('secret', 42)
 
     # We don't need to propagate a secret down to rice which is good because

--- a/examples/classes/example.py
+++ b/examples/classes/example.py
@@ -27,6 +27,6 @@ box = picobox.Box()
 box.put(Sender, factory=Sender, scope=picobox.singleton)
 box.put('document', 'cv.txt')
 
-with picobox.push(box):
+with picobox.pushpop(box):
     controller = Controller()
     controller.process()

--- a/examples/complex/example.py
+++ b/examples/complex/example.py
@@ -17,5 +17,5 @@ box = picobox.Box()
 box.put('conf', {'connection': 'sqlite://'})
 box.put('session', factory=session)
 
-with picobox.push(box):
+with picobox.pushpop(box):
     compute()

--- a/examples/flask/wsgi.py
+++ b/examples/flask/wsgi.py
@@ -18,5 +18,5 @@ box.put('magic', 12)
 # request (see Flask request context), but this way it would be harder
 # to test the app since any attempt to override dependencies in tests
 # will fail due to later attempt to push a new box by request hooks.
-picobox.push(box).__enter__()
+picobox.pushpop(box).__enter__()
 from example import app  # noqa

--- a/examples/requests/example.py
+++ b/examples/requests/example.py
@@ -19,7 +19,7 @@ def spam(session):
 box = picobox.Box()
 box.put('session', factory=requests.Session, scope=picobox.threadlocal)
 
-with picobox.push(box):
+with picobox.pushpop(box):
     # We have 3 threads and 10 spam calls which means there should be no more
     # than 3 different session instances (check session ID in the output).
     with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:

--- a/src/picobox/__init__.py
+++ b/src/picobox/__init__.py
@@ -2,7 +2,7 @@
 
 from ._box import Box, ChainBox
 from ._scopes import Scope, singleton, threadlocal, noscope
-from ._stack import push, put, get, pass_
+from ._stack import push, pushpop, put, get, pass_
 
 
 __all__ = [
@@ -15,6 +15,7 @@ __all__ = [
     'noscope',
 
     'push',
+    'pushpop',
     'put',
     'get',
     'pass_',

--- a/src/picobox/_stack.py
+++ b/src/picobox/_stack.py
@@ -2,6 +2,7 @@
 
 import threading
 import functools
+import warnings
 
 from ._box import Box, ChainBox
 
@@ -23,13 +24,13 @@ class _topbox:
 
         except IndexError:
             raise RuntimeError(
-                'No boxes found on stack, please use picobox.push() first.')
+                'No boxes found on stack, please use picobox.pushpop() first.')
 
 
 _topbox = _topbox()
 
 
-class push:
+class pushpop:
     """Context manager to push a :class:`Box` instance to the top of the stack.
 
     The box on the top is used by :func:`put`, :func:`get` and :func:`pass_`
@@ -37,7 +38,7 @@ class push:
     stacked interface. The idea behind stacked interface is to provide a way
     to easily switch DI containers (boxes) without changing injections.
 
-    Here's a minimal example of how push can be used::
+    Here's a minimal example of how it can be used::
 
         import picobox
 
@@ -51,8 +52,8 @@ class push:
         barbox = picobox.Box()
         barbox.put('magic', 13)
 
-        with picobox.push(foobox):
-            with picobox.push(barbox):
+        with picobox.pushpop(foobox):
+            with picobox.pushpop(barbox):
                 assert do() == 14
             assert do() == 43
 
@@ -84,6 +85,15 @@ class push:
         # alternative implementations.
         with self._lock:
             _stack.pop()
+
+
+def push(box, chain=False):
+    """Deprecated alias of :class:`pushpop`."""
+    warnings.warn(
+        'push() has been renamed into pushpop(); please use new name because '
+        'old one will be removed in picobox 2.0.',
+        DeprecationWarning)
+    return pushpop(box, chain)
 
 
 def _wraps(method):


### PR DESCRIPTION
The reason behind this awkward renaming is that it became clear that we
may need a way to push a box on stack in one place and pop it in
another. This idea basically means we need two standalone functions:
push() and pop(), and therefore the context manager needs to be renamed
in order to free a good name (i.e. push()) for other purpose.

Despite this renaming, picobox follows semantic versioning hence push()
will work as before till next major release - 2.0.