### PR TITLE
Make it possible to use push() as a regular function

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -230,6 +230,21 @@ not a solution.
             box.put('foo', 42)
             assert spam() == 42
 
+``picobox.push()`` can also be used as a regular function, not only as a
+context manager.
+
+.. code:: python
+
+     def test_spam():
+        box = picobox.push(picobox.Box(), chain=True)
+        box.put('foo', 42)
+        assert spam() == 42
+        picobox.pop()
+
+Every call to ``picobox.push()`` should eventually be followed by a corresponding
+call to ``picobox.pop()`` to remove the box from the top of the stack, when you
+are done with it.
+
 
 API reference
 -------------
@@ -267,6 +282,7 @@ Stacked API
 ```````````
 
 .. autofunction:: push
+.. autofunction:: pop
 .. autofunction:: put
 .. autofunction:: get
 .. autofunction:: pass_
@@ -280,6 +296,16 @@ Release Notes
     Picobox follows `Semantic Versioning <https://semver.org>`_ which means
     backward incompatible changes will be released along with bumping major
     version component.
+
+Unreleased
+``````````
+
+* ``picobox.push()`` can now be used as a regular function as well, not only
+  as a context manager.
+
+* New ``picobox.pop()`` function, that pops the box from the top of the stack.
+
+* Fixed a potential race condition on concurrent calls to ``picobox.push()``.
 
 1.1.0
 `````

--- a/examples/flask/example.py
+++ b/examples/flask/example.py
@@ -1,5 +1,5 @@
 import picobox
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request
 from tools import spam
 
 
@@ -17,4 +17,28 @@ def index():
 @app.route('/magic')
 @picobox.pass_('magic')
 def magic(magic):
+    return jsonify({'magic': magic})
+
+
+@app.before_request
+def serve_eggs_with_spam():
+    box = picobox.Box()
+
+    # on requests to /eggs, override the value of magic with 'spam'
+    if request.path == '/eggs':
+        box.put('magic', 'spam')
+
+    picobox.push(box, chain=True)
+
+
+@app.after_request
+def take_spam_away(response):
+    # pop the box from the top of the stack to remove the override
+    picobox.pop()
+    return response
+
+
+@app.route('/eggs')
+@picobox.pass_('magic')
+def eggs(magic):
     return jsonify({'magic': magic})

--- a/examples/flask/wsgi.py
+++ b/examples/flask/wsgi.py
@@ -18,5 +18,5 @@ box.put('magic', 12)
 # request (see Flask request context), but this way it would be harder
 # to test the app since any attempt to override dependencies in tests
 # will fail due to later attempt to push a new box by request hooks.
-picobox.push(box).__enter__()
+picobox.push(box)
 from example import app  # noqa

--- a/src/picobox/__init__.py
+++ b/src/picobox/__init__.py
@@ -2,7 +2,7 @@
 
 from ._box import Box, ChainBox
 from ._scopes import Scope, singleton, threadlocal, noscope
-from ._stack import push, put, get, pass_
+from ._stack import push, pop, put, get, pass_
 
 
 __all__ = [
@@ -15,6 +15,7 @@ __all__ = [
     'noscope',
 
     'push',
+    'pop',
     'put',
     'get',
     'pass_',

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -510,3 +510,27 @@ def test_chainbox_get_chained():
     with picobox.push(testchainbox):
         assert testchainbox.get('the-key') == 42
         assert testchainbox.get('the-pin') == 12
+
+
+def test_push_pop_as_regular_functions():
+    @picobox.pass_('magic')
+    def do(magic):
+        return magic + 1
+
+    foobox = picobox.Box()
+    foobox.put('magic', 42)
+
+    barbox = picobox.Box()
+    barbox.put('magic', 13)
+
+    picobox.push(foobox)
+    assert do() == 43
+    picobox.push(barbox)
+    assert do() == 14
+    picobox.pop()
+    picobox.pop()
+
+
+def test_pop_empty_stack():
+    with pytest.raises(IndexError):
+        picobox.pop()


### PR DESCRIPTION
While it's great, that push() works as a context manager and
automatically removes the last box from the top of the stack on exit,
it may be useful for push() to behave like a regular function sometimes,
e.g. for integration with frameworks, that have their own notion of
a context stack and want to be able to push/pop boxes explicitly.

pop() is added, so that it's possible to remove the last box from the
top of the stack.

While we are at it, also fix usage of threading.Lock in stack.py:
previously a new lock was created in push(), which did not make sense,
as it would effectively mean that concurrent threads would be acquiring
different locks.