### PR TITLE
Return popped box instance from picobox.pop()

### DIFF
--- a/src/picobox/_stack.py
+++ b/src/picobox/_stack.py
@@ -125,12 +125,11 @@ def pop():
 
     :raises: IndexError: if the stack is empty and there's nothing to pop
     """
-
     # Despite "list" is thread-safe in CPython (due to GIL), it's not
     # guaranteed by the language itself and may not be the case among
     # alternative implementations.
     with _lock:
-        _stack.pop()
+        return _stack.pop()
 
 
 def _wraps(method):

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -525,10 +525,12 @@ def test_push_pop_as_regular_functions():
 
     picobox.push(foobox)
     assert do() == 43
+
     picobox.push(barbox)
     assert do() == 14
-    picobox.pop()
-    picobox.pop()
+
+    assert picobox.pop() is barbox
+    assert picobox.pop() is foobox
 
 
 def test_pop_empty_stack():


### PR DESCRIPTION
Because there may be a couple of cases when you want to deal with just
popped box and it wasn't possible to do so without accessing internal
stack state. Besides, stack data structure usually returns a value from
pop() and since we can get it for free, why not? :)