### PR TITLE
Add .pytest_cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ pip-delete-this-directory.txt
 .coverage
 .coverage.*
 .cache
+.pytest_cache
 nosetests.xml
 coverage.xml
 


### PR DESCRIPTION
Starting with pytest 3.4, its internal .cache directory has been renamed
into .pytest_cache. So we better extend .gitignore with this name in
order to prevent accidental committing temporary files.