### PR TITLE
Small enhancements in docstrings for API reference

### DIFF
--- a/src/picobox/_box.py
+++ b/src/picobox/_box.py
@@ -160,7 +160,7 @@ class Box(object):
 
         :param key: A key to retrieve a dependency. Must be the one used when
             calling :meth:`.put` method.
-        :parameter as\_: (optional) Bind a dependency associated with `key` to
+        :param as\_: (optional) Bind a dependency associated with `key` to
             a function argument named `as_`. If not passed, the same as `key`.
         :raises KeyError: If no dependencies saved under `key` in the box.
         """

--- a/src/picobox/_stack.py
+++ b/src/picobox/_stack.py
@@ -77,23 +77,13 @@ def push(box, chain=False):
 
     As a regular function::
 
-        import picobox
-
-        @picobox.pass_('magic')
-        def do(magic):
-            return magic + 1
-
-        foobox = picobox.Box()
-        foobox.put('magic', 42)
-
-        barbox = picobox.Box()
-        barbox.put('magic', 13)
-
         picobox.push(foobox)
-        assert do() == 43
         picobox.push(barbox)
+
         assert do() == 14
         picobox.pop()
+
+        assert do() == 43
         picobox.pop()
 
     :param box: A :class:`Box` instance to push to the top of the stack.


### PR DESCRIPTION
Nothing much, really. Just make one example shorter in push() docstring
assuming *setup* context of the example above, and use *param* instead
of *parameter* to describe function's argument to be consistent with the
code around.