### PR TITLE
Use travis-ci.com instead of travis-ci.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@ Picobox
 .. image:: https://img.shields.io/pypi/v/picobox.svg
    :target: https://pypi.python.org/pypi/picobox
 
-.. image:: https://travis-ci.org/ikalnytskyi/picobox.svg
-   :target: https://travis-ci.org/ikalnytskyi/picobox
+.. image:: https://travis-ci.com/ikalnytskyi/picobox.svg?branch=master
+   :target: https://travis-ci.com/ikalnytskyi/picobox.svg?branch=master
 
 .. image:: https://codecov.io/gh/ikalnytskyi/picobox/branch/master/graph/badge.svg
    :target: https://codecov.io/gh/ikalnytskyi/picobox


### PR DESCRIPTION
The project has been moved from travis-ci.org to travis-ci.com because
the former is deprecated and the latter more feature rich and requests
less permissions on GitHub.