### PR TITLE
Ensure any hashable keys & any values are allowed

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -297,6 +297,11 @@ Release Notes
     backward incompatible changes will be released along with bumping major
     version component.
 
+Not released changes.
+
+* Fix ``picobox.threadlocal`` issue when it was impossible to use any hashable
+  key other than ``str``.
+
 2.0.0
 `````
 

--- a/src/picobox/_scopes.py
+++ b/src/picobox/_scopes.py
@@ -45,14 +45,18 @@ class threadlocal(Scope):
     """Share instances across the same thread."""
 
     def __init__(self):
-        self._store = threading.local()
+        self._local = threading.local()
 
     def set(self, key, value):
-        setattr(self._store, key, value)
+        try:
+            store = self._local.store
+        except AttributeError:
+            store = self._local.store = {}
+        store[key] = value
 
     def get(self, key):
         try:
-            rv = getattr(self._store, key)
+            rv = self._local.store[key]
         except AttributeError:
             raise KeyError("'%s'" % key)
         return rv

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,49 @@
+"""Setup pytest environment."""
+
+import pytest
+import picobox
+
+
+@pytest.fixture(scope='function', params=[
+    42,
+    '42',
+    42.42,
+    True,
+    None,
+    (1, None, True),
+    object(),
+])
+def hashable_value(request):
+    return request.param
+
+
+@pytest.fixture(scope='function', params=[
+    42,
+    '42',
+    42.42,
+    True,
+    None,
+    {'a': 1, 'b': 2},
+    {'a', 'b', 'c'},
+    [1, 2, 'c'],
+    (1, None, True),
+    object(),
+    lambda: 42,
+])
+def any_value(request):
+    return request.param
+
+
+@pytest.fixture(scope='function')
+def supported_key(hashable_value):
+    return hashable_value
+
+
+@pytest.fixture(scope='function')
+def supported_value(any_value):
+    return any_value
+
+
+@pytest.fixture(params=[picobox.Box, picobox.ChainBox])
+def boxclass(request):
+    yield request.param

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -7,45 +7,18 @@ import pytest
 import picobox
 
 
-@pytest.fixture(params=[picobox.Box, picobox.ChainBox])
-def boxclass(request):
-    yield request.param
-
-
-@pytest.mark.parametrize('key', [
-    42,
-    '42',
-    42.42,
-    True,
-    None,
-    (1, None, True),
-    object(),
-])
-def test_box_put_key(key, boxclass):
+def test_box_put_key(boxclass, supported_key):
     testbox = boxclass()
-    testbox.put(key, 'the-value')
+    testbox.put(supported_key, 'the-value')
 
-    assert testbox.get(key) == 'the-value'
+    assert testbox.get(supported_key) == 'the-value'
 
 
-@pytest.mark.parametrize('value', [
-    42,
-    '42',
-    42.42,
-    True,
-    None,
-    {'a': 1, 'b': 2},
-    {'a', 'b', 'c'},
-    [1, 2, 'c'],
-    (1, None, True),
-    object(),
-    lambda: 42,
-])
-def test_box_put_value(value, boxclass):
+def test_box_put_value(boxclass, supported_value):
     testbox = boxclass()
-    testbox.put('the-key', value)
+    testbox.put('the-key', supported_value)
 
-    assert testbox.get('the-key') is value
+    assert testbox.get('the-key') is supported_value
 
 
 def test_box_put_factory(boxclass):

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -6,6 +6,29 @@ import pytest
 import picobox
 
 
+@pytest.mark.parametrize('scopeclass', [
+    picobox.singleton,
+    picobox.threadlocal,
+])
+def test_scope_set_key(scopeclass, supported_key):
+    scope = scopeclass()
+    value = object()
+
+    scope.set(supported_key, value)
+    assert scope.get(supported_key) is value
+
+
+@pytest.mark.parametrize('scopeclass', [
+    picobox.singleton,
+    picobox.threadlocal,
+])
+def test_scope_set_value(scopeclass, supported_value):
+    scope = scopeclass()
+
+    scope.set('the-key', supported_value)
+    assert scope.get('the-key') is supported_value
+
+
 def test_singleton():
     scope = picobox.singleton()
     value = object()

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -4,49 +4,22 @@ import pytest
 import picobox
 
 
-@pytest.fixture(params=[picobox.Box, picobox.ChainBox])
-def boxclass(request):
-    yield request.param
-
-
-@pytest.mark.parametrize('key', [
-    42,
-    '42',
-    42.42,
-    True,
-    None,
-    (1, None, True),
-    object(),
-])
-def test_box_put_key(key, boxclass):
+def test_box_put_key(boxclass, supported_key):
     testbox = boxclass()
 
     with picobox.push(testbox):
-        picobox.put(key, 'the-value')
+        picobox.put(supported_key, 'the-value')
 
-    assert testbox.get(key) == 'the-value'
+    assert testbox.get(supported_key) == 'the-value'
 
 
-@pytest.mark.parametrize('value', [
-    42,
-    '42',
-    42.42,
-    True,
-    None,
-    {'a': 1, 'b': 2},
-    {'a', 'b', 'c'},
-    [1, 2, 'c'],
-    (1, None, True),
-    object(),
-    lambda: 42,
-])
-def test_box_put_value(value, boxclass):
+def test_box_put_value(boxclass, supported_value):
     testbox = boxclass()
 
     with picobox.push(testbox):
-        picobox.put('the-key', value)
+        picobox.put('the-key', supported_value)
 
-    assert testbox.get('the-key') is value
+    assert testbox.get('the-key') is supported_value
 
 
 def test_box_put_factory(boxclass):


### PR DESCRIPTION
Picobox claims to support any hashable keys to identify dependencies,
and any values as dependencies. This property directly depends on
scopes' implementations, so we need to make sure that built-in ones
supports this claim.

P.S: It turns out that `picobox.threadlocal` did not support that,
so this patch fixes the issue along with introducing tests.