### PR TITLE
Add 'contextvars' based scope

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
       python: '3.5'
     - env: TOXENV=py36
       python: '3.6'
+    - env: TOXENV=py37
+      python: '3.7-dev'
     - env: TOXENV=pypy3
       python: 'pypy3'
     - env: TOXENV=metadata

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,7 @@ exclude_patterns = ['_build', '_themes']
 pygments_style = 'sphinx'
 intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
 autodoc_member_order = 'bysource'
+autodoc_mock_imports = ['contextvars']
 
 # -- HTML output
 html_use_index = False

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -275,6 +275,15 @@ Scopes
 .. autodata:: threadlocal
     :annotation:
 
+.. autodata:: contextvars
+    :annotation:
+
+    Since `asyncio does support context variables`__, the scope could be used
+    in asynchronous applications to share dependencies between coroutines of
+    the same :class:`asyncio.Task`.
+
+    .. __: https://docs.python.org/3.7/library/contextvars.html#asyncio-support
+
 .. autodata:: noscope
     :annotation:
 
@@ -299,8 +308,13 @@ Release Notes
 
 Not released changes.
 
+* Add ``picobox.contextvars`` scope (python 3.7 and above) that can be used
+  in asyncio applications to have a separate set of dependencies in all
+  coroutines of the same task.
+
 * Fix ``picobox.threadlocal`` issue when it was impossible to use any hashable
   key other than ``str``.
+
 
 2.0.0
 `````

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setuptools.setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Libraries',

--- a/src/picobox/__init__.py
+++ b/src/picobox/__init__.py
@@ -4,6 +4,11 @@ from ._box import Box, ChainBox
 from ._scopes import Scope, singleton, threadlocal, noscope
 from ._stack import push, pop, put, get, pass_
 
+try:
+    from ._scopes import contextvars
+except ImportError:
+    pass
+
 
 __all__ = [
     'Box',
@@ -12,6 +17,7 @@ __all__ = [
     'Scope',
     'singleton',
     'threadlocal',
+    'contextvars',
     'noscope',
 
     'push',


### PR DESCRIPTION
Context Variables is a new feature of Python 3.7 designed to solve
context local storage problem of asynchronous code. Despite being
not tied to asynchronous code, its main value is in asyncio support.

Please beware these two facts:

 * At the moment only asyncio supports contexts which means by using
   contextvars scope you can have separate set of dependencies for
   each coroutine. Neither curio nor trio support it.

 * Context Variables are not shared between threads which means
   contextvars scope could be used instead of threadlocal in some
   cases.

For more details please see

 https://docs.python.org/3.7/library/contextvars.html
 https://www.python.org/dev/peps/pep-0567/