### PR TITLE
Set PEP 345 Project-URL metadata in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,11 @@ setuptools.setup(
     setup_requires=[
         'setuptools_scm',
     ],
+    project_urls={
+        'Documentation': 'https://picobox.readthedocs.io',
+        'Source': 'https://github.com/ikalnytskyi/picobox',
+        'Bugs': 'https://github.com/ikalnytskyi/picobox/issues',
+    },
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
By setting one or more Project-URL entries in metadata, PyPI can display
helpful hyperlinks in a generic manner. This is something we would like
to show to get better attraction.