### PR TITLE
Squash neighbor 'picobox.pass_' calls into one

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -315,6 +315,8 @@ Not released changes.
 * Fix ``picobox.threadlocal`` issue when it was impossible to use any hashable
   key other than ``str``.
 
+* Nested ``picobox.pass_`` calls are now squashed into one in order to
+  improve runtime performance.
 
 2.0.0
 `````


### PR DESCRIPTION
Each 'picobox.pass_' call adds an additional runtime cost to inspect
wrapped function signature and to find not passed (aka to be injected)
arguments. There is no sense in doing this again and again. So we better
squash 'picobox.pass_' calls into one, so at runtime we will inspect
wrapped function only once.