### PR TITLE
Add Python 2.7 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ cache: pip
 
 matrix:
   include:
+    - env: TOXENV=py27
+      python: '2.7'
     - env: TOXENV=py34
       python: '3.4'
     - env: TOXENV=py35
@@ -14,6 +16,8 @@ matrix:
       python: '3.6'
     - env: TOXENV=py37
       python: '3.7-dev'
+    - env: TOXENV=pypy
+      python: 'pypy'
     - env: TOXENV=pypy3
       python: 'pypy3'
     - env: TOXENV=metadata

--- a/README.rst
+++ b/README.rst
@@ -29,11 +29,11 @@ Features
 --------
 
 * Support both values and factories.
-* Support scopes (e.g. singleton, threadlocal).
+* Support scopes (e.g. singleton, threadlocal, contextvars).
 * Push boxes on stack, and use the top one to access values.
 * Thread-safe.
-* Lightweight ( ~141 LOC ).
-* Zero dependencies.
+* Lightweight (~213 LOC including scopes).
+* Zero dependencies (on python3).
 * Pure Python.
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -318,6 +318,8 @@ Not released changes.
 * Nested ``picobox.pass_`` calls are now squashed into one in order to
   improve runtime performance.
 
+* Add ``Python 2.7`` support.
+
 2.0.0
 `````
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,9 @@ setuptools.setup(
     setup_requires=[
         'setuptools_scm',
     ],
+    install_requires=[
+        'funcsigs; python_version < "3"',
+    ],
     project_urls={
         'Documentation': 'https://picobox.readthedocs.io',
         'Source': 'https://github.com/ikalnytskyi/picobox',
@@ -35,6 +38,8 @@ setuptools.setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/src/picobox/_box.py
+++ b/src/picobox/_box.py
@@ -1,10 +1,9 @@
 """Box container."""
 
 import functools
-import inspect
 import threading
 
-from . import _scopes
+from . import _scopes, _compat
 
 
 # Missing is a special sentinel object that's used to indicate a value is
@@ -173,7 +172,7 @@ class Box(object):
 
             @functools.wraps(fn)
             def wrapper(*args, **kwargs):
-                signature = inspect.signature(fn)
+                signature = _compat.signature(fn)
                 arguments = signature.bind_partial(*args, **kwargs)
 
                 for key, as_ in wrapper.__dependencies__:

--- a/src/picobox/_compat.py
+++ b/src/picobox/_compat.py
@@ -1,0 +1,28 @@
+"""Py2/Py3 compatibility misc."""
+
+import sys
+
+
+if sys.version_info[0] > 2:
+    signature = __import__('inspect').signature
+else:
+    # inspect.signature has been introduced in Python 3.3 and older versions
+    # have to use third-party 'funcsigs' package instead.
+    signature = __import__('funcsigs').signature
+
+
+# This piece of code is copied from six library and is distributed under the
+# same license (http://six.readthedocs.io/#six.add_metaclass).
+def add_metaclass(metaclass):
+    def wrapper(cls):
+        orig_vars = cls.__dict__.copy()
+        slots = orig_vars.get('__slots__')
+        if slots is not None:
+            if isinstance(slots, str):
+                slots = [slots]
+            for slots_var in slots:
+                orig_vars.pop(slots_var)
+        orig_vars.pop('__dict__', None)
+        orig_vars.pop('__weakref__', None)
+        return metaclass(cls.__name__, cls.__bases__, orig_vars)
+    return wrapper

--- a/src/picobox/_scopes.py
+++ b/src/picobox/_scopes.py
@@ -8,8 +8,11 @@ try:
 except ImportError:
     _contextvars = None
 
+from . import _compat
 
-class Scope(metaclass=abc.ABCMeta):
+
+@_compat.add_metaclass(abc.ABCMeta)
+class Scope(object):
     """Scope is an execution context based storage interface.
 
     Execution context is a mechanism of storing and accessing data bound to a

--- a/src/picobox/_stack.py
+++ b/src/picobox/_stack.py
@@ -16,7 +16,7 @@ _lock = threading.Lock()
 # interface but deal with a box at the top. While it's not completely necessary
 # for methods like put() and get(), it's crucial for pass_() due to its
 # lazyness.
-class _topbox:
+class _topbox(object):
 
     def __getattribute__(self, name):
         try:
@@ -145,4 +145,9 @@ def get(*args, **kwargs):
 @_wraps(Box.pass_)
 def pass_(*args, **kwargs):
     """The same as :meth:`Box.pass_` but for a box at the top of the stack."""
-    return Box.pass_(_topbox, *args, **kwargs)
+    # Box.pass_(_topbox, *args, **kwargs) does not work in Python 2 because
+    # Box.pass_ is an unbound method, and unbound methods require class
+    # instance as its first argument. Therefore, we need a workaround to
+    # extract a function without "method" wrapping, so we can pass anything
+    # as the first argument.
+    return vars(Box)['pass_'](_topbox, *args, **kwargs)

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -8,6 +8,8 @@ import traceback
 import pytest
 import picobox
 
+from picobox import _compat
+
 
 def test_box_put_key(boxclass, supported_key):
     testbox = boxclass()
@@ -460,7 +462,7 @@ def test_chainbox_isinstance_box():
     for name, _ in inspect.getmembers(picobox.Box) if not name.startswith('_')
 ])
 def test_chainbox_box_interface(name):
-    boxsignature = inspect.signature(getattr(picobox.Box(), name))
-    chainboxsignature = inspect.signature(getattr(picobox.ChainBox(), name))
+    boxsignature = _compat.signature(getattr(picobox.Box(), name))
+    chainboxsignature = _compat.signature(getattr(picobox.ChainBox(), name))
 
     assert boxsignature == chainboxsignature


### PR DESCRIPTION
According to Status of Python Branches [1], Python 2.7 is the only
supported python from 2.x era, and it will be supported till 2020. That
said, there are plenty of projects still running on Python 2.7 due to
technical reasons (or legacy) and it would be nice to provide decent DI
for such projects. :)

[1]: https://devguide.python.org/#status-of-python-branches