### PR TITLE
Use 'py3' tox env instead of 'py36' by default

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, pypy3, metadata, pep8, docs
+envlist = py3, pypy3, metadata, pep8, docs
 
 [testenv]
 deps =


### PR DESCRIPTION
Because nowadays python 3.7 is more popular on developer machines rather
than python 3.6. So let's do not tie to a particular python version and
run on any available python3 instead.