### PR TITLE
Travis CI: deploy a universal wheel to PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ jobs:
     - stage: pypi
       deploy:
         provider: pypi
-        distributions: sdist bdist_wheel
+        distributions: sdist bdist_wheel --universal
         on:
           tags: true
         user: $PYPI_USERNAME


### PR DESCRIPTION
Otherwise, only a py2 wheel is built and deployed to PyPI. :(