### PR TITLE
Do not cast keys to string via str formatting

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -306,6 +306,12 @@ Release Notes
     backward incompatible changes will be released along with bumping major
     version component.
 
+Not released changes.
+
+* Fix ``picobox.singleton``, ``picobox.threadlocal`` & ``picobox.contextvars``
+  scopes so they do not fail with unexpected exception when non-string
+  formattable missing key is passed.
+
 2.1.0
 `````
 

--- a/src/picobox/_scopes.py
+++ b/src/picobox/_scopes.py
@@ -66,7 +66,7 @@ class threadlocal(Scope):
         try:
             rv = self._local.store[key]
         except AttributeError:
-            raise KeyError("'%s'" % key)
+            raise KeyError(key)
         return rv
 
 
@@ -87,7 +87,7 @@ class contextvars(Scope):
         try:
             return self._store[key].get()
         except LookupError:
-            raise KeyError("'%s'" % key)
+            raise KeyError(key)
 
 
 class noscope(Scope):
@@ -97,7 +97,7 @@ class noscope(Scope):
         pass
 
     def get(self, key):
-        raise KeyError("'%s'" % key)
+        raise KeyError(key)
 
 
 if not _contextvars:

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -91,32 +91,19 @@ def test_scope_contextvars_attribute_error(monkeypatch):
     'threadlocal',
     'contextvars',
 ])
-def test_scope_set_key(request, scopename, supported_key):
-    scope = request.getfixturevalue(scopename)
-    value = object()
-
-    scope.set(supported_key, value)
-    assert scope.get(supported_key) is value
-
-
-@pytest.mark.parametrize('scopename', [
-    'singleton',
-    'threadlocal',
-    'contextvars',
-])
-def test_scope_set_value(request, scopename, supported_value):
+def test_scope_set(request, scopename, supported_key, supported_value):
     scope = request.getfixturevalue(scopename)
 
-    scope.set('the-key', supported_value)
-    assert scope.get('the-key') is supported_value
+    scope.set(supported_key, supported_value)
+    assert scope.get(supported_key) is supported_value
 
 
-def test_scope_set_value_noscope():
+def test_scope_set_noscope(supported_key, supported_value):
     scope = picobox.noscope()
-    scope.set('the-key', 'the-value')
+    scope.set(supported_key, supported_value)
 
-    with pytest.raises(KeyError, match='the-key'):
-        scope.get('the-key')
+    with pytest.raises(KeyError, match=str(supported_key)):
+        scope.get(supported_key)
 
 
 @pytest.mark.parametrize('scopename', [
@@ -124,7 +111,7 @@ def test_scope_set_value_noscope():
     'threadlocal',
     'contextvars',
 ])
-def test_scope_set_value_overwrite(request, scopename):
+def test_scope_set_overwrite(request, scopename):
     scope = request.getfixturevalue(scopename)
     value = object()
 
@@ -141,11 +128,11 @@ def test_scope_set_value_overwrite(request, scopename):
     'contextvars',
     'noscope',
 ])
-def test_scope_get_keyerror(request, scopename):
+def test_scope_get_keyerror(request, scopename, supported_key):
     scope = request.getfixturevalue(scopename)
 
-    with pytest.raises(KeyError, match='the-key'):
-        scope.get('the-key')
+    with pytest.raises(KeyError, match=repr(supported_key)):
+        scope.get(supported_key)
 
 
 @pytest.mark.parametrize('scopename', [


### PR DESCRIPTION
It turns out that using such valid keys as tuples do not play properly
with old string formatting:

```
    >>> raise KeyError("'%s'" % (42, 'foo'))
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
    TypeError: not all arguments converted during string formatting
```

The proper solution will be to use a key "As Is" and let KeyError to
cast its arguments to strings.