### PR TITLE
Add Flask application/request scopes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ exclude_patterns = ['_build', '_themes']
 pygments_style = 'sphinx'
 intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
 autodoc_member_order = 'bysource'
-autodoc_mock_imports = ['contextvars']
+autodoc_mock_imports = ['contextvars', 'flask']
 
 # -- HTML output
 html_use_index = False

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -287,6 +287,12 @@ Scopes
 .. autodata:: noscope
     :annotation:
 
+.. autodata:: picobox.contrib.flaskscopes.application
+    :annotation:
+
+.. autodata:: picobox.contrib.flaskscopes.request
+    :annotation:
+
 Stacked API
 ```````````
 
@@ -311,6 +317,9 @@ Not released changes.
 * Fix ``picobox.singleton``, ``picobox.threadlocal`` & ``picobox.contextvars``
   scopes so they do not fail with unexpected exception when non-string
   formattable missing key is passed.
+
+* Add ``picobox.contrib.flaskscopes`` module with *application* and *request*
+  scopes for Flask web framework.
 
 2.1.0
 `````

--- a/src/picobox/contrib/__init__.py
+++ b/src/picobox/contrib/__init__.py
@@ -1,0 +1,1 @@
+"""Lock, Stock and Two Smoking Barrels."""

--- a/src/picobox/contrib/flaskscopes.py
+++ b/src/picobox/contrib/flaskscopes.py
@@ -1,0 +1,40 @@
+"""Scopes for Flask framework."""
+
+import picobox
+import flask
+
+
+class _flaskscope(picobox.Scope):
+    """A base class for Flask scopes."""
+
+    _store = None
+
+    def set(self, key, value):
+        try:
+            dependencies = self._store.__dependencies__
+        except AttributeError:
+            dependencies = self._store.__dependencies__ = {}
+        dependencies[key] = value
+
+    def get(self, key):
+        try:
+            rv = self._store.__dependencies__[key]
+        except AttributeError:
+            raise KeyError(key)
+        return rv
+
+
+class application(_flaskscope):
+    """Share instances across the same Flask (HTTP) application."""
+
+    @property
+    def _store(self):
+        return flask.current_app
+
+
+class request(_flaskscope):
+    """Share instances across the same Flask (HTTP) request."""
+
+    @property
+    def _store(self):
+        return flask.g

--- a/tests/contrib/test_flaskscopes.py
+++ b/tests/contrib/test_flaskscopes.py
@@ -1,0 +1,135 @@
+"""Test Flask scopes."""
+
+import flask
+import pytest
+
+from picobox.contrib import flaskscopes
+
+
+@pytest.fixture(scope='function')
+def appscope():
+    return flaskscopes.application()
+
+
+@pytest.fixture(scope='function')
+def reqscope():
+    return flaskscopes.request()
+
+
+@pytest.fixture(scope='function')
+def flaskapp():
+    return flask.Flask('test')
+
+
+@pytest.fixture(scope='function')
+def appcontext(flaskapp):
+    return flaskapp.app_context
+
+
+@pytest.fixture(scope='function')
+def reqcontext(flaskapp):
+    return flaskapp.test_request_context
+
+
+@pytest.mark.parametrize('scopename, ctx', [
+    ('appscope', 'appcontext'),
+    ('reqscope', 'reqcontext'),
+])
+def test_scope_set(request, scopename, ctx, supported_key, supported_value):
+    scope = request.getfixturevalue(scopename)
+    ctxfn = request.getfixturevalue(ctx)
+
+    with ctxfn():
+        scope.set(supported_key, supported_value)
+        assert scope.get(supported_key) is supported_value
+
+
+@pytest.mark.parametrize('scopename', [
+    'appscope',
+    'reqscope',
+])
+def test_scope_set_nocontext(request, scopename):
+    scope = request.getfixturevalue(scopename)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        scope.set('the-key', 'the-value')
+    excinfo.match('Working outside of application context.')
+
+
+@pytest.mark.parametrize('scopename, ctx', [
+    ('appscope', 'appcontext'),
+    ('reqscope', 'reqcontext'),
+])
+def test_scope_set_value_overwrite(request, scopename, ctx):
+    scope = request.getfixturevalue(scopename)
+    ctxfn = request.getfixturevalue(ctx)
+    value = object()
+
+    with ctxfn():
+        scope.set('the-key', value)
+        assert scope.get('the-key') is value
+
+        scope.set('the-key', 'overwrite')
+        assert scope.get('the-key') == 'overwrite'
+
+
+@pytest.mark.parametrize('scopename, ctx', [
+    ('appscope', 'appcontext'),
+    ('reqscope', 'reqcontext'),
+])
+def test_scope_get_keyerror(request, scopename, ctx, supported_key):
+    scope = request.getfixturevalue(scopename)
+    ctxfn = request.getfixturevalue(ctx)
+
+    with pytest.raises(KeyError, match=repr(supported_key)):
+        with ctxfn():
+            scope.get(supported_key)
+
+
+@pytest.mark.parametrize('scopename, ctx', [
+    ('appscope', 'appcontext'),
+])
+def test_scope_value_shared(request, scopename, ctx):
+    scope = request.getfixturevalue(scopename)
+    ctxfn = request.getfixturevalue(ctx)
+    value = object()
+
+    with ctxfn():
+        scope.set('the-key', value)
+
+    with ctxfn():
+        assert scope.get('the-key') is value
+
+
+@pytest.mark.parametrize('scopename, ctx', [
+    ('reqscope', 'reqcontext'),
+])
+def test_scope_value_not_shared(request, scopename, ctx):
+    scope = request.getfixturevalue(scopename)
+    ctxfn = request.getfixturevalue(ctx)
+
+    with ctxfn():
+        scope.set('the-key', 'the-value')
+
+    with pytest.raises(KeyError, match='the-key'):
+        with ctxfn():
+            scope.get('the-key')
+
+
+def test_scope_value_not_shared_between_apps(appscope):
+    eggs = flask.Flask('eggs')
+    rice = flask.Flask('rice')
+    value = object()
+
+    with eggs.app_context():
+        appscope.set('the-key', value)
+
+    with eggs.app_context():
+        assert appscope.get('the-key') is value
+
+    with pytest.raises(KeyError, match='the-key'):
+        with rice.app_context():
+            appscope.get('the-key')
+
+    with eggs.app_context():
+        assert appscope.get('the-key') is value

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = py3, pypy3, metadata, pep8, docs
 deps =
     coverage
     pytest
+    flask
 commands =
     {envpython} -m coverage run -m pytest --strict {posargs:}
     {envpython} -m coverage combine


### PR DESCRIPTION
Flask is a popular web framework among Python community. Any web
framework has at minimum two contexts:

 * application context
 * request context

There may be a lot of use cases for these contexts. For instance, one
may want to generate and store a request ID, or a database connection
per request. Anyhow, having Picobox scopes for these two contexts is
a big win with no costs.