### PR TITLE
Use 'r' for docstring to pass new lint rules

### DIFF
--- a/src/picobox/_box.py
+++ b/src/picobox/_box.py
@@ -149,7 +149,7 @@ class Box(object):
         return value
 
     def pass_(self, key, as_=_missing):
-        """Pass a dependency to a function if nothing explicitly passed.
+        r"""Pass a dependency to a function if nothing explicitly passed.
 
         The decorator implements late binding which means it does not require
         to have a dependency instance in the box before applying. The instance


### PR DESCRIPTION
Since flake8 3.6.0, a newer version of pycodestyle is used where it's
not allowed to have invalid escaped characers in strings [1]. For
instance, in our case we want to escape some reStructuredText syntax and
thus we want a backslash to be preserved and passed to docutils
directly. In order to make this proper way, we have to use so-called raw
strings (i.e. with 'r' prefix).

[1] https://github.com/PyCQA/pycodestyle/issues/755