### PR TITLE
Add picobox.Stack() to manage boxes on stack

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -235,7 +235,7 @@ context manager.
 
 .. code:: python
 
-     def test_spam():
+    def test_spam():
         box = picobox.push(picobox.Box(), chain=True)
         box.put('foo', 42)
         assert spam() == 42
@@ -244,6 +244,30 @@ context manager.
 Every call to ``picobox.push()`` should eventually be followed by a corresponding
 call to ``picobox.pop()`` to remove the box from the top of the stack, when you
 are done with it.
+
+.. note::
+
+    Dependency Injection is usually used in applications, not libraries, to
+    wire things together. Occasionally such need may come in libraries too, so
+    picobox provides a :class:`picobox.Stack` class to create an independent
+    non overlapping stack with boxes suitable to be used in such cases.
+
+    Just create a global instance of stack (globals themeselves aren't bad),
+    and use it as you'd use picobox stacked interface:
+
+    .. code:: python
+
+        import picobox
+
+        stack = picobox.Stack()
+
+        @stack.pass_('a', as_='b')
+        def mysum(a, b):
+            return a + b
+
+        with stack.push(picobox.Box()) as box:
+            box.put('a', 42)
+            assert mysum(13) == 55
 
 
 API reference
@@ -296,6 +320,9 @@ Scopes
 Stacked API
 ```````````
 
+.. autoclass:: Stack
+    :members:
+
 .. autofunction:: push
 .. autofunction:: pop
 .. autofunction:: put
@@ -320,6 +347,10 @@ Not released changes.
 
 * Add ``picobox.contrib.flaskscopes`` module with *application* and *request*
   scopes for Flask web framework.
+
+* Add ``picobox.Stack`` class to create stacks with boxes on demand. Might
+  be useful for third-party developers who want to use picobox yet avoid
+  collisions with main application developers.
 
 2.1.0
 `````

--- a/src/picobox/__init__.py
+++ b/src/picobox/__init__.py
@@ -2,7 +2,7 @@
 
 from ._box import Box, ChainBox
 from ._scopes import Scope, singleton, threadlocal, noscope
-from ._stack import push, pop, put, get, pass_
+from ._stack import Stack, push, pop, put, get, pass_
 
 try:
     from ._scopes import contextvars
@@ -20,6 +20,7 @@ __all__ = [
     'contextvars',
     'noscope',
 
+    'Stack',
     'push',
     'pop',
     'put',


### PR DESCRIPTION
Picobox is providing a stacked interface where you can use
picobox.push(), picobox.put(), and company to manage your boxes on
stack. However, the stack was shared and that caused some issues like
inability to use stacked interface in third party libraries due to a
possible collision with a consumer application. As the solution to the
proble, picobox now provides picobox.Stack() class that allows to create
any number of stacks you can use whenever and wherever you want.
Existing picobox.push(), picobox.put() and company functions now deals
with pre-created shared stack instance for backward compatibility and to
provide a quick and ad hoc way to use picobox.