### PR TITLE
Add a docstring to picobox.Stack() class

### DIFF
--- a/src/picobox/_box.py
+++ b/src/picobox/_box.py
@@ -29,7 +29,7 @@ class Box(object):
     exactly when to reuse them or when to create new ones. That is to say each
     scope defines a set of rules for when to reuse dependencies.
 
-    Here's a minimal example of how Box instance can be used::
+    Here's a minimal example of how a Box instance can be used::
 
         import picobox
 


### PR DESCRIPTION
Since docstrings are used by Sphinx to generate the API reference, we
want to provide a good and meaningful description of the class.