### PR TITLE
Use 'versionadded' directive in docstrings

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -302,12 +302,6 @@ Scopes
 .. autodata:: contextvars
     :annotation:
 
-    Since `asyncio does support context variables`__, the scope could be used
-    in asynchronous applications to share dependencies between coroutines of
-    the same :class:`asyncio.Task`.
-
-    .. __: https://docs.python.org/3.7/library/contextvars.html#asyncio-support
-
 .. autodata:: noscope
     :annotation:
 

--- a/src/picobox/_box.py
+++ b/src/picobox/_box.py
@@ -220,6 +220,8 @@ class ChainBox(Box):
 
     :param boxes: (optional) A list of boxes to lookup into. If no boxes are
         passed, an empty box is created and used as underlying box instead.
+
+    .. versionadded:: 1.1
     """
 
     def __init__(self, *boxes):

--- a/src/picobox/_scopes.py
+++ b/src/picobox/_scopes.py
@@ -71,7 +71,16 @@ class threadlocal(Scope):
 
 
 class contextvars(Scope):
-    """Share instances across the same execution context (:pep:`567`)."""
+    """Share instances across the same execution context (:pep:`567`).
+
+    Since `asyncio does support context variables`__, the scope could be used
+    in asynchronous applications to share dependencies between coroutines of
+    the same :class:`asyncio.Task`.
+
+    .. __: https://docs.python.org/3.7/library/contextvars.html#asyncio-support
+
+    .. versionadded:: 2.1
+    """
 
     def __init__(self):
         self._store = {}

--- a/src/picobox/_stack.py
+++ b/src/picobox/_stack.py
@@ -181,13 +181,19 @@ _instance = Stack('shared')
 
 @_copy_signature(Stack.push, _instance)
 def push(*args, **kwargs):
-    """The same as :meth:`Stack.push` but for a shared stack instance."""
+    """The same as :meth:`Stack.push` but for a shared stack instance.
+
+    .. versionadded:: 1.1 ``chain`` parameter
+    """
     return _instance.push(*args, **kwargs)
 
 
 @_copy_signature(Stack.pop, _instance)
 def pop(*args, **kwargs):
-    """The same as :meth:`Stack.pop` but for a shared stack instance."""
+    """The same as :meth:`Stack.pop` but for a shared stack instance.
+
+    .. versionadded:: 2.0
+    """
     return _instance.pop(*args, **kwargs)
 
 

--- a/src/picobox/contrib/flaskscopes.py
+++ b/src/picobox/contrib/flaskscopes.py
@@ -25,7 +25,17 @@ class _flaskscope(picobox.Scope):
 
 
 class application(_flaskscope):
-    """Share instances across the same Flask (HTTP) application."""
+    """Share instances across the same Flask (HTTP) application.
+
+    In most cases can be used interchangeably with :class:`picobox.singleton`
+    scope. Comes around when you have `multiple Flask applications`__ and you
+    want to have independent instances for each Flask application, despite
+    the fact they are running in the same WSGI context.
+
+    .. __: http://flask.pocoo.org/docs/1.0/patterns/appdispatch/
+
+    .. versionadded:: 2.2
+    """
 
     @property
     def _store(self):
@@ -33,7 +43,10 @@ class application(_flaskscope):
 
 
 class request(_flaskscope):
-    """Share instances across the same Flask (HTTP) request."""
+    """Share instances across the same Flask (HTTP) request.
+
+    .. versionadded:: 2.2
+    """
 
     @property
     def _store(self):


### PR DESCRIPTION
In order to provide a good API reference in docs, we need to use both
meaningful docstrings and versionadded/versionchanged directives to give
users a context on what was added when.