### PR TITLE
Isolate dependencies between Flask scopes

### DIFF
--- a/src/picobox/contrib/flaskscopes.py
+++ b/src/picobox/contrib/flaskscopes.py
@@ -1,5 +1,7 @@
 """Scopes for Flask framework."""
 
+import uuid
+
 import picobox
 import flask
 
@@ -9,17 +11,32 @@ class _flaskscope(picobox.Scope):
 
     _store = None
 
+    def __init__(self):
+        # Both application and request scopes are merely proxies to
+        # corresponding storage objects in Flask. This means multiple
+        # scope instances will share the same storage object under the
+        # hood, and this is not what we want. So we need to generate
+        # some unique key per scope instance and use that key to
+        # distinguish dependencies stored by different scope instances.
+        self._uuid = str(uuid.uuid4())
+
     def set(self, key, value):
         try:
             dependencies = self._store.__dependencies__
         except AttributeError:
             dependencies = self._store.__dependencies__ = {}
+
+        try:
+            dependencies = dependencies[self._uuid]
+        except KeyError:
+            dependencies = dependencies.setdefault(self._uuid, {})
+
         dependencies[key] = value
 
     def get(self, key):
         try:
-            rv = self._store.__dependencies__[key]
-        except AttributeError:
+            rv = self._store.__dependencies__[self._uuid][key]
+        except (AttributeError, KeyError):
             raise KeyError(key)
         return rv
 


### PR DESCRIPTION
There's a bug in Flask scopes where dependencies for the same Flask
scope are shared between different boxes. It turns out that the problem
lies in the fact that the scopes use shared Flask "storages" like "g"
and "current_app". In order to implement isolation, we need to tie
dependencies to a scope instance somehow.