### PR TITLE
Run tests on Python 3.8 and 3.9 on CI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,8 +11,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python
+      - name: Setup Python
         uses: actions/setup-python@v2
+
+      - name: Setup dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade twine
 
       - name: Prepare artifacts
         run: |
@@ -23,5 +28,4 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: |
-          python -m pip install twine
           twine upload dist/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,25 +12,29 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python
+      - name: Setup Python
         uses: actions/setup-python@v2
+
+      - name: Setup dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade tox
 
       - name: Run lints
         run: |
-          python -m pip install tox
           python -m tox -e metadata,pep8
 
   pytest:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.6", "3.7", "pypy-3.7"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "pypy-3.7"]
 
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Setup Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
@@ -39,9 +43,13 @@ jobs:
       run: |
         git submodule update --init --recursive
 
+    - name: Setup dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade tox
+
     - name: Run pytest
       run: |
-        python -m pip install tox
         python -m tox -e py
 
   docs:
@@ -49,10 +57,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python
+      - name: Setup Python
         uses: actions/setup-python@v2
+
+      - name: Setup dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade tox
 
       - name: Run sphinx
         run: |
-          python -m pip install tox
           python -m tox -e docs

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,8 @@ setuptools.setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Libraries',


### PR DESCRIPTION
In order to guarantee that picobox works perfectly fine on Python 3.8
and 3.9, let's test these builds on CI.