### PR TITLE
Use Black to ensure code formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,9 @@
 repos:
+  - repo: https://github.com/psf/black
+    rev: 20.8b1
+    hooks:
+      - id: black
+
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.1
     hooks:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,29 +5,30 @@ import pkg_resources
 
 
 # -- Project settings
-project = 'Picobox'
-copyright = '2017, Ihor Kalnytskyi'
-release = pkg_resources.get_distribution('picobox').version
-version = '.'.join(release.split('.')[:2])
+project = "Picobox"
+copyright = "2017, Ihor Kalnytskyi"
+release = pkg_resources.get_distribution("picobox").version
+version = ".".join(release.split(".")[:2])
 
 # -- General settings
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx']
-source_suffix = '.rst'
-master_doc = 'index'
-exclude_patterns = ['_build', '_themes']
-pygments_style = 'sphinx'
-intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
-autodoc_member_order = 'bysource'
-autodoc_mock_imports = ['contextvars', 'flask']
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.intersphinx"]
+source_suffix = ".rst"
+master_doc = "index"
+exclude_patterns = ["_build", "_themes"]
+pygments_style = "sphinx"
+intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
+autodoc_member_order = "bysource"
+autodoc_mock_imports = ["contextvars", "flask"]
 
 # -- HTML output
 html_use_index = False
 html_show_sourcelink = False
-html_logo = '_static/picobox.svg'
+html_logo = "_static/picobox.svg"
 
-if not os.environ.get('READTHEDOCS') == 'True':
+if not os.environ.get("READTHEDOCS") == "True":
     import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
+
+    html_theme = "sphinx_rtd_theme"
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Sphinx does not support "code" directive preserving default (docutils)
@@ -38,6 +39,7 @@ if not os.environ.get('READTHEDOCS') == 'True':
 # See https://github.com/sphinx-doc/sphinx/issues/2155 for details.
 from docutils.parsers.rst import directives
 from sphinx.directives.code import CodeBlock
-directives.register_directive('code', CodeBlock)
+
+directives.register_directive("code", CodeBlock)
 
 # flake8: noqa

--- a/examples/cascade/example.py
+++ b/examples/cascade/example.py
@@ -9,13 +9,13 @@ def eggs():
     return rice()
 
 
-@picobox.pass_('secret')
+@picobox.pass_("secret")
 def rice(secret):
     print(secret)
 
 
 with picobox.push(picobox.Box()) as box:
-    box.put('secret', 42)
+    box.put("secret", 42)
 
     # We don't need to propagate a secret down to rice which is good because
     # we kept interface clear (i.e. no changes in spam and eggs signatures).

--- a/examples/classes/example.py
+++ b/examples/classes/example.py
@@ -11,21 +11,21 @@ class Controller:
     # Picobox supports injections by type (key may be any hashable object),
     # though in this case you have to explicitly map the key onto argument
     # name.
-    @picobox.pass_(Sender, as_='sender')
+    @picobox.pass_(Sender, as_="sender")
     def __init__(self, sender):
         self._sender = sender
 
     # Many alternative solutions support injections to __init__ only while
     # Picobox allows to inject arguments wherever you want. You are the
     # only one to decide what would be the better way.
-    @picobox.pass_('document')
+    @picobox.pass_("document")
     def process(self, document):
-        self._sender.send('processing ' + document)
+        self._sender.send("processing " + document)
 
 
 box = picobox.Box()
 box.put(Sender, factory=Sender, scope=picobox.singleton)
-box.put('document', 'cv.txt')
+box.put("document", "cv.txt")
 
 with picobox.push(box):
     controller = Controller()

--- a/examples/complex/example.py
+++ b/examples/complex/example.py
@@ -1,21 +1,22 @@
 import picobox
 
 
-@picobox.pass_('conf')
+@picobox.pass_("conf")
 def session(conf):
     class Session:
-        connection = conf['connection']
+        connection = conf["connection"]
+
     return Session()
 
 
-@picobox.pass_('session')
+@picobox.pass_("session")
 def compute(session):
     print(session.connection)
 
 
 box = picobox.Box()
-box.put('conf', {'connection': 'sqlite://'})
-box.put('session', factory=session)
+box.put("conf", {"connection": "sqlite://"})
+box.put("session", factory=session)
 
 with picobox.push(box):
     compute()

--- a/examples/flask/example.py
+++ b/examples/flask/example.py
@@ -3,21 +3,21 @@ from flask import Flask, jsonify, request
 from tools import spam
 
 
-app = Flask('example')
+app = Flask("example")
 
 
-@app.route('/')
+@app.route("/")
 def index():
-    return jsonify({'spam': spam()})
+    return jsonify({"spam": spam()})
 
 
 # @app.route() internally saves wrapped function inside, so decorators order
 # here does matter and if you want to inject some argument using picobox,
 # you ought to apply @picobox.pass_ before @app.route.
-@app.route('/magic')
-@picobox.pass_('magic')
+@app.route("/magic")
+@picobox.pass_("magic")
 def magic(magic):
-    return jsonify({'magic': magic})
+    return jsonify({"magic": magic})
 
 
 @app.before_request
@@ -25,8 +25,8 @@ def serve_eggs_with_spam():
     box = picobox.Box()
 
     # on requests to /eggs, override the value of magic with 'spam'
-    if request.path == '/eggs':
-        box.put('magic', 'spam')
+    if request.path == "/eggs":
+        box.put("magic", "spam")
 
     picobox.push(box, chain=True)
 
@@ -38,7 +38,7 @@ def take_spam_away(response):
     return response
 
 
-@app.route('/eggs')
-@picobox.pass_('magic')
+@app.route("/eggs")
+@picobox.pass_("magic")
 def eggs(magic):
-    return jsonify({'magic': magic})
+    return jsonify({"magic": magic})

--- a/examples/flask/tools.py
+++ b/examples/flask/tools.py
@@ -9,6 +9,6 @@ def eggs():
     return rice()
 
 
-@picobox.pass_('magic')
+@picobox.pass_("magic")
 def rice(magic):
     return magic + 1

--- a/examples/flask/wsgi.py
+++ b/examples/flask/wsgi.py
@@ -2,7 +2,7 @@ import picobox
 
 
 box = picobox.Box()
-box.put('magic', 12)
+box.put("magic", 12)
 
 # The app instance exposed via this module is used to run the app for
 # development (flask run) as well as for production (uWSGI, Gunicorn).

--- a/examples/requests/example.py
+++ b/examples/requests/example.py
@@ -5,19 +5,20 @@ import picobox
 import requests
 
 
-@picobox.pass_('session')
+@picobox.pass_("session")
 def spam(session):
-    return 'thread={}; session={}; ip={}'.format(
+    return "thread={}; session={}; ip={}".format(
         threading.get_ident(),
         id(session),
-        session.get('https://httpbin.org/ip').json()['origin'])
+        session.get("https://httpbin.org/ip").json()["origin"],
+    )
 
 
 # According to https://github.com/kennethreitz/requests/issues/2766
 # requests.Session() is not thread-safe. Therefore we need to create
 # a separate session for each thread.
 box = picobox.Box()
-box.put('session', factory=requests.Session, scope=picobox.threadlocal)
+box.put("session", factory=requests.Session, scope=picobox.threadlocal)
 
 with picobox.push(box):
     # We have 3 threads and 10 spam calls which means there should be no more

--- a/setup.py
+++ b/setup.py
@@ -5,43 +5,43 @@ import setuptools
 
 here = os.path.dirname(__file__)
 
-with io.open(os.path.join(here, 'README.rst'), 'r', encoding='utf-8') as f:
+with io.open(os.path.join(here, "README.rst"), "r", encoding="utf-8") as f:
     long_description = f.read()
 
 
 setuptools.setup(
-    name='picobox',
-    description='Dependency injection framework designed with Python in mind.',
+    name="picobox",
+    description="Dependency injection framework designed with Python in mind.",
     long_description=long_description,
-    url='https://github.com/ikalnytskyi/picobox',
-    license='MIT',
-    author='Ihor Kalnytskyi',
-    author_email='ihor@kalnytskyi.com',
-    packages=setuptools.find_packages(where='src'),
-    package_dir={'': 'src'},
+    url="https://github.com/ikalnytskyi/picobox",
+    license="MIT",
+    author="Ihor Kalnytskyi",
+    author_email="ihor@kalnytskyi.com",
+    packages=setuptools.find_packages(where="src"),
+    package_dir={"": "src"},
     use_scm_version={
-        'root': here,
+        "root": here,
     },
     setup_requires=[
-        'setuptools_scm',
+        "setuptools_scm",
     ],
     project_urls={
-        'Documentation': 'https://picobox.readthedocs.io',
-        'Source': 'https://github.com/ikalnytskyi/picobox',
-        'Bugs': 'https://github.com/ikalnytskyi/picobox/issues',
+        "Documentation": "https://picobox.readthedocs.io",
+        "Source": "https://github.com/ikalnytskyi/picobox",
+        "Bugs": "https://github.com/ikalnytskyi/picobox/issues",
     },
     classifiers=[
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Programming Language :: Python :: Implementation :: PyPy',
-        'Topic :: Software Development :: Libraries',
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy",
+        "Topic :: Software Development :: Libraries",
     ],
 )

--- a/src/picobox/__init__.py
+++ b/src/picobox/__init__.py
@@ -11,19 +11,17 @@ except ImportError:
 
 
 __all__ = [
-    'Box',
-    'ChainBox',
-
-    'Scope',
-    'singleton',
-    'threadlocal',
-    'contextvars',
-    'noscope',
-
-    'Stack',
-    'push',
-    'pop',
-    'put',
-    'get',
-    'pass_',
+    "Box",
+    "ChainBox",
+    "Scope",
+    "singleton",
+    "threadlocal",
+    "contextvars",
+    "noscope",
+    "Stack",
+    "push",
+    "pop",
+    "put",
+    "get",
+    "pass_",
 ]

--- a/src/picobox/_box.py
+++ b/src/picobox/_box.py
@@ -13,7 +13,7 @@ from . import _scopes
 # API reference (see docs).
 class _missing:
     def __repr__(self):
-        return '<optional>'
+        return "<optional>"
 
 
 _missing = _missing()
@@ -71,10 +71,8 @@ class Box(object):
             a class that implements :class:`Scope` interface.
         :raises ValueError: If both `value` and `factory` are passed.
         """
-        if value is not _missing \
-                and (factory is not _missing or scope is not _missing):
-            raise ValueError(
-                "either 'value' or 'factory'/'scope' pair must be passed")
+        if value is not _missing and (factory is not _missing or scope is not _missing):
+            raise ValueError("either 'value' or 'factory'/'scope' pair must be passed")
 
         # Value is a syntax sugar Box supports to store objects "As Is"
         # with singleton scope. In other words it's essentially the same
@@ -83,8 +81,10 @@ class Box(object):
         # in this case it wouldn't support values which are callable by
         # its nature.
         if value is not _missing:
+
             def factory():
                 return value
+
             scope = _scopes.singleton
 
         # If scope is not explicitly passed, Box assumes "No Scope"
@@ -164,10 +164,11 @@ class Box(object):
             a function argument named `as_`. If not passed, the same as `key`.
         :raises KeyError: If no dependencies saved under `key` in the box.
         """
+
         def decorator(fn):
             # If pass_ decorator is called second time (or more), we can squash
             # the calls into one and reduce runtime costs of injection.
-            if hasattr(fn, '__dependencies__'):
+            if hasattr(fn, "__dependencies__"):
                 fn.__dependencies__.append((key, as_))
                 return fn
 
@@ -187,8 +188,10 @@ class Box(object):
                     if as_ not in arguments.arguments:
                         kwargs[as_] = self.get(key)
                 return fn(*args, **kwargs)
+
             wrapper.__dependencies__ = [(key, as_)]
             return wrapper
+
         return decorator
 
 

--- a/src/picobox/_scopes.py
+++ b/src/picobox/_scopes.py
@@ -86,7 +86,7 @@ class contextvars(Scope):
         try:
             var = self._store[key]
         except KeyError:
-            var = self._store[key] = _contextvars.ContextVar('picobox')
+            var = self._store[key] = _contextvars.ContextVar("picobox")
         var.set(value)
 
     def get(self, key):

--- a/src/picobox/_stack.py
+++ b/src/picobox/_stack.py
@@ -24,12 +24,14 @@ def _copy_signature(method, instance=None):
 
 def _create_stack_proxy(stack, empty_stack_error):
     """Create an object that proxies all calls to the top of the stack."""
+
     class _StackProxy(object):
         def __getattribute__(self, name):
             try:
                 return getattr(stack[-1], name)
             except IndexError:
                 raise RuntimeError(empty_stack_error)
+
     return _StackProxy()
 
 
@@ -100,14 +102,15 @@ class Stack(object):
         # that mimic Box interface but deal with a box on the top instead.
         # While it's not completely necessary for `put()` and `get()`, it's
         # crucial for `pass_()` due to its laziness and thus late evaluation.
-        self._topbox = _create_stack_proxy(self._stack, (
-            'No boxes found on the stack, please `.push()` a box first.'))
+        self._topbox = _create_stack_proxy(
+            self._stack, "No boxes found on the stack, please `.push()` a box first."
+        )
 
     def __repr__(self):
         name = self._name
         if not self._name:
-            name = '0x%x' % id(self)
-        return '<Stack (%s)>' % name
+            name = "0x%x" % id(self)
+        return "<Stack (%s)>" % name
 
     def push(self, box, chain=False):
         """Push a :class:`Box` instance to the top of the stack.
@@ -173,10 +176,10 @@ class Stack(object):
         # instance as its first argument. Therefore, we need a workaround to
         # extract a function without "method" wrapping, so we can pass anything
         # as the first argument.
-        return vars(Box)['pass_'](self._topbox, *args, **kwargs)
+        return vars(Box)["pass_"](self._topbox, *args, **kwargs)
 
 
-_instance = Stack('shared')
+_instance = Stack("shared")
 
 
 @_copy_signature(Stack.push, _instance)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,42 +4,48 @@ import pytest
 import picobox
 
 
-@pytest.fixture(scope='function', params=[
-    42,
-    '42',
-    42.42,
-    True,
-    None,
-    (1, None, True),
-    object(),
-])
+@pytest.fixture(
+    scope="function",
+    params=[
+        42,
+        "42",
+        42.42,
+        True,
+        None,
+        (1, None, True),
+        object(),
+    ],
+)
 def hashable_value(request):
     return request.param
 
 
-@pytest.fixture(scope='function', params=[
-    42,
-    '42',
-    42.42,
-    True,
-    None,
-    {'a': 1, 'b': 2},
-    {'a', 'b', 'c'},
-    [1, 2, 'c'],
-    (1, None, True),
-    object(),
-    lambda: 42,
-])
+@pytest.fixture(
+    scope="function",
+    params=[
+        42,
+        "42",
+        42.42,
+        True,
+        None,
+        {"a": 1, "b": 2},
+        {"a", "b", "c"},
+        [1, 2, "c"],
+        (1, None, True),
+        object(),
+        lambda: 42,
+    ],
+)
 def any_value(request):
     return request.param
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def supported_key(hashable_value):
     return hashable_value
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def supported_value(any_value):
     return any_value
 

--- a/tests/contrib/test_flaskscopes.py
+++ b/tests/contrib/test_flaskscopes.py
@@ -6,35 +6,38 @@ import pytest
 from picobox.contrib import flaskscopes
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def appscope():
     return flaskscopes.application()
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def reqscope():
     return flaskscopes.request()
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def flaskapp():
-    return flask.Flask('test')
+    return flask.Flask("test")
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def appcontext(flaskapp):
     return flaskapp.app_context
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def reqcontext(flaskapp):
     return flaskapp.test_request_context
 
 
-@pytest.mark.parametrize('scopename, ctx', [
-    ('appscope', 'appcontext'),
-    ('reqscope', 'reqcontext'),
-])
+@pytest.mark.parametrize(
+    "scopename, ctx",
+    [
+        ("appscope", "appcontext"),
+        ("reqscope", "reqcontext"),
+    ],
+)
 def test_scope_set(request, scopename, ctx, supported_key, supported_value):
     scope = request.getfixturevalue(scopename)
     ctxfn = request.getfixturevalue(ctx)
@@ -44,39 +47,48 @@ def test_scope_set(request, scopename, ctx, supported_key, supported_value):
         assert scope.get(supported_key) is supported_value
 
 
-@pytest.mark.parametrize('scopename', [
-    'appscope',
-    'reqscope',
-])
+@pytest.mark.parametrize(
+    "scopename",
+    [
+        "appscope",
+        "reqscope",
+    ],
+)
 def test_scope_set_nocontext(request, scopename):
     scope = request.getfixturevalue(scopename)
 
     with pytest.raises(RuntimeError) as excinfo:
-        scope.set('the-key', 'the-value')
-    excinfo.match('Working outside of application context.')
+        scope.set("the-key", "the-value")
+    excinfo.match("Working outside of application context.")
 
 
-@pytest.mark.parametrize('scopename, ctx', [
-    ('appscope', 'appcontext'),
-    ('reqscope', 'reqcontext'),
-])
+@pytest.mark.parametrize(
+    "scopename, ctx",
+    [
+        ("appscope", "appcontext"),
+        ("reqscope", "reqcontext"),
+    ],
+)
 def test_scope_set_value_overwrite(request, scopename, ctx):
     scope = request.getfixturevalue(scopename)
     ctxfn = request.getfixturevalue(ctx)
     value = object()
 
     with ctxfn():
-        scope.set('the-key', value)
-        assert scope.get('the-key') is value
+        scope.set("the-key", value)
+        assert scope.get("the-key") is value
 
-        scope.set('the-key', 'overwrite')
-        assert scope.get('the-key') == 'overwrite'
+        scope.set("the-key", "overwrite")
+        assert scope.get("the-key") == "overwrite"
 
 
-@pytest.mark.parametrize('scopename, ctx', [
-    ('appscope', 'appcontext'),
-    ('reqscope', 'reqcontext'),
-])
+@pytest.mark.parametrize(
+    "scopename, ctx",
+    [
+        ("appscope", "appcontext"),
+        ("reqscope", "reqcontext"),
+    ],
+)
 def test_scope_get_keyerror(request, scopename, ctx, supported_key):
     scope = request.getfixturevalue(scopename)
     ctxfn = request.getfixturevalue(ctx)
@@ -86,10 +98,13 @@ def test_scope_get_keyerror(request, scopename, ctx, supported_key):
             scope.get(supported_key)
 
 
-@pytest.mark.parametrize('scopename, ctx', [
-    ('appscope', 'appcontext'),
-    ('reqscope', 'reqcontext'),
-])
+@pytest.mark.parametrize(
+    "scopename, ctx",
+    [
+        ("appscope", "appcontext"),
+        ("reqscope", "reqcontext"),
+    ],
+)
 def test_scope_state_not_leaked(request, scopename, ctx):
     ctxfn = request.getfixturevalue(ctx)
 
@@ -100,63 +115,69 @@ def test_scope_state_not_leaked(request, scopename, ctx):
     value_b = object()
 
     with ctxfn():
-        scope_a.set('the-key', value_a)
-        assert scope_a.get('the-key') is value_a
+        scope_a.set("the-key", value_a)
+        assert scope_a.get("the-key") is value_a
 
-        with pytest.raises(KeyError, match='the-key'):
-            scope_b.get('the-key')
+        with pytest.raises(KeyError, match="the-key"):
+            scope_b.get("the-key")
 
-        scope_b.set('the-key', value_b)
-        assert scope_b.get('the-key') is value_b
+        scope_b.set("the-key", value_b)
+        assert scope_b.get("the-key") is value_b
 
-        scope_a.set('the-key', value_a)
-        assert scope_a.get('the-key') is value_a
+        scope_a.set("the-key", value_a)
+        assert scope_a.get("the-key") is value_a
 
 
-@pytest.mark.parametrize('scopename, ctx', [
-    ('appscope', 'appcontext'),
-])
+@pytest.mark.parametrize(
+    "scopename, ctx",
+    [
+        ("appscope", "appcontext"),
+    ],
+)
 def test_scope_value_shared(request, scopename, ctx):
     scope = request.getfixturevalue(scopename)
     ctxfn = request.getfixturevalue(ctx)
     value = object()
 
     with ctxfn():
-        scope.set('the-key', value)
+        scope.set("the-key", value)
 
     with ctxfn():
-        assert scope.get('the-key') is value
+        assert scope.get("the-key") is value
 
 
-@pytest.mark.parametrize('scopename, ctx', [
-    ('reqscope', 'reqcontext'),
-])
+@pytest.mark.parametrize(
+    "scopename, ctx",
+    [
+        ("reqscope", "reqcontext"),
+    ],
+)
 def test_scope_value_not_shared(request, scopename, ctx):
     scope = request.getfixturevalue(scopename)
     ctxfn = request.getfixturevalue(ctx)
 
     with ctxfn():
-        scope.set('the-key', 'the-value')
+        scope.set("the-key", "the-value")
 
-    with pytest.raises(KeyError, match='the-key'):
+    with pytest.raises(KeyError, match="the-key"):
         with ctxfn():
-            scope.get('the-key')
+            scope.get("the-key")
 
 
 def test_scope_value_not_shared_between_apps(appscope):
-    eggs = flask.Flask('eggs')
-    rice = flask.Flask('rice')
+    eggs = flask.Flask("eggs")
+    rice = flask.Flask("rice")
     value = object()
 
     with eggs.app_context():
-        appscope.set('the-key', value)
+        appscope.set("the-key", value)
 
     with eggs.app_context():
-        assert appscope.get('the-key') is value
+        assert appscope.get("the-key") is value
 
-    with pytest.raises(KeyError, match='the-key'):
+    with pytest.raises(KeyError, match="the-key"):
         with rice.app_context():
-            appscope.get('the-key')
+            appscope.get("the-key")
 
     with eggs.app_context():
-        assert appscope.get('the-key') is value
+        assert appscope.get("the-key") is value

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -11,23 +11,23 @@ import picobox
 
 def test_box_put_key(boxclass, supported_key):
     testbox = boxclass()
-    testbox.put(supported_key, 'the-value')
+    testbox.put(supported_key, "the-value")
 
-    assert testbox.get(supported_key) == 'the-value'
+    assert testbox.get(supported_key) == "the-value"
 
 
 def test_box_put_value(boxclass, supported_value):
     testbox = boxclass()
-    testbox.put('the-key', supported_value)
+    testbox.put("the-key", supported_value)
 
-    assert testbox.get('the-key') is supported_value
+    assert testbox.get("the-key") is supported_value
 
 
 def test_box_put_factory(boxclass):
     testbox = boxclass()
-    testbox.put('the-key', factory=object)
+    testbox.put("the-key", factory=object)
 
-    objects = [testbox.get('the-key') for _ in range(10)]
+    objects = [testbox.get("the-key") for _ in range(10)]
 
     assert len(objects) == 10
     assert len(set(map(id, objects))) == 10
@@ -35,9 +35,9 @@ def test_box_put_factory(boxclass):
 
 def test_box_put_factory_singleton_scope(boxclass):
     testbox = boxclass()
-    testbox.put('the-key', factory=object, scope=picobox.singleton)
+    testbox.put("the-key", factory=object, scope=picobox.singleton)
 
-    objects = [testbox.get('the-key') for _ in range(10)]
+    objects = [testbox.get("the-key") for _ in range(10)]
 
     assert len(objects) == 10
     assert len(set(map(id, objects))) == 1
@@ -45,7 +45,6 @@ def test_box_put_factory_singleton_scope(boxclass):
 
 def test_box_put_factory_custom_scope(boxclass):
     class namespacescope(picobox.Scope):
-
         def __init__(self):
             self._store = collections.defaultdict(dict)
 
@@ -56,21 +55,25 @@ def test_box_put_factory_custom_scope(boxclass):
             return self._store[namespace][key]
 
     testbox = boxclass()
-    testbox.put('the-key', factory=object, scope=namespacescope)
+    testbox.put("the-key", factory=object, scope=namespacescope)
 
     objects = []
 
-    namespace = 'one'
-    objects.extend([
-        testbox.get('the-key'),
-        testbox.get('the-key'),
-    ])
+    namespace = "one"
+    objects.extend(
+        [
+            testbox.get("the-key"),
+            testbox.get("the-key"),
+        ]
+    )
 
-    namespace = 'two'
-    objects.extend([
-        testbox.get('the-key'),
-        testbox.get('the-key'),
-    ])
+    namespace = "two"
+    objects.extend(
+        [
+            testbox.get("the-key"),
+            testbox.get("the-key"),
+        ]
+    )
 
     assert len(objects) == 4
     assert len(set(map(id, objects[:2]))) == 1
@@ -81,21 +84,21 @@ def test_box_put_factory_custom_scope(boxclass):
 def test_box_put_factory_dependency(boxclass):
     testbox = boxclass()
 
-    @testbox.pass_('a')
+    @testbox.pass_("a")
     def fn(a):
         return a + 1
 
-    testbox.put('a', 13)
-    testbox.put('b', factory=fn)
+    testbox.put("a", 13)
+    testbox.put("b", factory=fn)
 
-    assert testbox.get('b') == 14
+    assert testbox.get("b") == 14
 
 
 def test_box_put_value_and_factory(boxclass):
     testbox = boxclass()
 
     with pytest.raises(ValueError) as excinfo:
-        testbox.put('the-key', 42, factory=object)
+        testbox.put("the-key", 42, factory=object)
     excinfo.match("either 'value' or 'factory'/'scope' pair must be passed")
 
 
@@ -103,244 +106,277 @@ def test_box_put_value_and_scope(boxclass):
     testbox = boxclass()
 
     with pytest.raises(ValueError) as excinfo:
-        testbox.put('the-key', 42, scope=picobox.threadlocal)
+        testbox.put("the-key", 42, scope=picobox.threadlocal)
     excinfo.match("either 'value' or 'factory'/'scope' pair must be passed")
 
 
 def test_box_get_keyerror(boxclass):
     testbox = boxclass()
 
-    with pytest.raises(KeyError, match='the-key'):
-        testbox.get('the-key')
+    with pytest.raises(KeyError, match="the-key"):
+        testbox.get("the-key")
 
 
 def test_box_get_default(boxclass):
     testbox = boxclass()
     sentinel = object()
 
-    assert testbox.get('the-key', sentinel) is sentinel
+    assert testbox.get("the-key", sentinel) is sentinel
 
 
-@pytest.mark.parametrize('args, kwargs, rv', [
-    ((1, 2, 3),     {},                               6),
-    ((1, 2),        {'c': 3},                         6),
-    ((1,),          {'b': 2, 'c': 3},                 6),
-    ((),            {'a': 1, 'b': 2, 'c': 3},         6),
-    ((),            {'b': 2, 'c': 3},                15),
-])
+@pytest.mark.parametrize(
+    "args, kwargs, rv",
+    [
+        ((1, 2, 3), {}, 6),
+        ((1, 2), {"c": 3}, 6),
+        ((1,), {"b": 2, "c": 3}, 6),
+        ((), {"a": 1, "b": 2, "c": 3}, 6),
+        ((), {"b": 2, "c": 3}, 15),
+    ],
+)
 def test_box_pass_a(args, kwargs, rv, boxclass):
     testbox = boxclass()
-    testbox.put('a', 10)
+    testbox.put("a", 10)
 
-    @testbox.pass_('a')
+    @testbox.pass_("a")
     def fn(a, b, c):
         return a + b + c
 
     assert fn(*args, **kwargs) == rv
 
 
-@pytest.mark.parametrize('args, kwargs, rv', [
-    ((1, 2, 3),     {},                               6),
-    ((1, 2),        {'c': 3},                         6),
-    ((1,),          {'b': 2, 'c': 3},                 6),
-    ((1,),          {'c': 3},                        14),
-    ((),            {'a': 1, 'b': 2, 'c': 3},         6),
-    ((),            {'a': 1, 'c': 3},                14),
-])
+@pytest.mark.parametrize(
+    "args, kwargs, rv",
+    [
+        ((1, 2, 3), {}, 6),
+        ((1, 2), {"c": 3}, 6),
+        ((1,), {"b": 2, "c": 3}, 6),
+        ((1,), {"c": 3}, 14),
+        ((), {"a": 1, "b": 2, "c": 3}, 6),
+        ((), {"a": 1, "c": 3}, 14),
+    ],
+)
 def test_box_pass_b(args, kwargs, rv, boxclass):
     testbox = boxclass()
-    testbox.put('b', 10)
+    testbox.put("b", 10)
 
-    @testbox.pass_('b')
+    @testbox.pass_("b")
     def fn(a, b, c):
         return a + b + c
 
     assert fn(*args, **kwargs) == rv
 
 
-@pytest.mark.parametrize('args, kwargs, rv', [
-    ((1, 2, 3),     {},                               6),
-    ((1, 2),        {'c': 3},                         6),
-    ((1, 2),        {},                              13),
-    ((1,),          {'b': 2, 'c': 3},                 6),
-    ((1,),          {'b': 2},                        13),
-    ((),            {'a': 1, 'b': 2, 'c': 3},         6),
-    ((),            {'a': 1, 'b': 2},                13),
-])
+@pytest.mark.parametrize(
+    "args, kwargs, rv",
+    [
+        ((1, 2, 3), {}, 6),
+        ((1, 2), {"c": 3}, 6),
+        ((1, 2), {}, 13),
+        ((1,), {"b": 2, "c": 3}, 6),
+        ((1,), {"b": 2}, 13),
+        ((), {"a": 1, "b": 2, "c": 3}, 6),
+        ((), {"a": 1, "b": 2}, 13),
+    ],
+)
 def test_box_pass_c(args, kwargs, rv, boxclass):
     testbox = boxclass()
-    testbox.put('c', 10)
+    testbox.put("c", 10)
 
-    @testbox.pass_('c')
+    @testbox.pass_("c")
     def fn(a, b, c):
         return a + b + c
 
     assert fn(*args, **kwargs) == rv
 
 
-@pytest.mark.parametrize('args, kwargs, rv', [
-    ((1, 2, 3),     {},                               6),
-    ((1, 2),        {'c': 3},                         6),
-    ((1, 2),        {},                              13),
-    ((1,),          {'b': 2, 'c': 3},                 6),
-    ((1,),          {'b': 2},                        13),
-    ((),            {'a': 1, 'b': 2, 'c': 3},         6),
-    ((),            {'a': 1, 'b': 2},                13),
-])
+@pytest.mark.parametrize(
+    "args, kwargs, rv",
+    [
+        ((1, 2, 3), {}, 6),
+        ((1, 2), {"c": 3}, 6),
+        ((1, 2), {}, 13),
+        ((1,), {"b": 2, "c": 3}, 6),
+        ((1,), {"b": 2}, 13),
+        ((), {"a": 1, "b": 2, "c": 3}, 6),
+        ((), {"a": 1, "b": 2}, 13),
+    ],
+)
 def test_box_pass_c_default(args, kwargs, rv, boxclass):
     testbox = boxclass()
-    testbox.put('c', 10)
+    testbox.put("c", 10)
 
-    @testbox.pass_('c')
+    @testbox.pass_("c")
     def fn(a, b, c=20):
         return a + b + c
 
     assert fn(*args, **kwargs) == rv
 
 
-@pytest.mark.parametrize('args, kwargs, rv', [
-    ((1, 2, 3),     {},                               6),
-    ((1, 2),        {'c': 3},                         6),
-    ((1,),          {'b': 2, 'c': 3},                 6),
-    ((1,),          {'c': 3},                       104),
-    ((),            {'a': 1, 'b': 2, 'c': 3},         6),
-    ((),            {'a': 1, 'c': 3},               104),
-    ((),            {'b': 2, 'c': 3},                15),
-    ((),            {'c': 3},                       113),
-])
+@pytest.mark.parametrize(
+    "args, kwargs, rv",
+    [
+        ((1, 2, 3), {}, 6),
+        ((1, 2), {"c": 3}, 6),
+        ((1,), {"b": 2, "c": 3}, 6),
+        ((1,), {"c": 3}, 104),
+        ((), {"a": 1, "b": 2, "c": 3}, 6),
+        ((), {"a": 1, "c": 3}, 104),
+        ((), {"b": 2, "c": 3}, 15),
+        ((), {"c": 3}, 113),
+    ],
+)
 def test_box_pass_ab(args, kwargs, rv, boxclass):
     testbox = boxclass()
-    testbox.put('a', 10)
-    testbox.put('b', 100)
+    testbox.put("a", 10)
+    testbox.put("b", 100)
 
-    @testbox.pass_('a')
-    @testbox.pass_('b')
+    @testbox.pass_("a")
+    @testbox.pass_("b")
     def fn(a, b, c):
         return a + b + c
 
     assert fn(*args, **kwargs) == rv
 
 
-@pytest.mark.parametrize('args, kwargs, rv', [
-    ((1, 2, 3),     {},                               6),
-    ((1, 2),        {'c': 3},                         6),
-    ((1, 2),        {},                             103),
-    ((1,),          {'b': 2, 'c': 3},                 6),
-    ((1,),          {'b': 2},                       103),
-    ((1,),          {'c': 3},                        14),
-    ((1,),          {},                             111),
-    ((),            {'a': 1, 'b': 2, 'c': 3},         6),
-    ((),            {'a': 1, 'b': 2},               103),
-    ((),            {'a': 1, 'c': 3},                14),
-    ((),            {'a': 1},                       111),
-])
+@pytest.mark.parametrize(
+    "args, kwargs, rv",
+    [
+        ((1, 2, 3), {}, 6),
+        ((1, 2), {"c": 3}, 6),
+        ((1, 2), {}, 103),
+        ((1,), {"b": 2, "c": 3}, 6),
+        ((1,), {"b": 2}, 103),
+        ((1,), {"c": 3}, 14),
+        ((1,), {}, 111),
+        ((), {"a": 1, "b": 2, "c": 3}, 6),
+        ((), {"a": 1, "b": 2}, 103),
+        ((), {"a": 1, "c": 3}, 14),
+        ((), {"a": 1}, 111),
+    ],
+)
 def test_box_pass_bc(args, kwargs, rv, boxclass):
     testbox = boxclass()
-    testbox.put('b', 10)
-    testbox.put('c', 100)
+    testbox.put("b", 10)
+    testbox.put("c", 100)
 
-    @testbox.pass_('b')
-    @testbox.pass_('c')
+    @testbox.pass_("b")
+    @testbox.pass_("c")
     def fn(a, b, c):
         return a + b + c
 
     assert fn(*args, **kwargs) == rv
 
 
-@pytest.mark.parametrize('args, kwargs, rv', [
-    ((1, 2, 3),     {},                               6),
-    ((1, 2),        {'c': 3},                         6),
-    ((1, 2),        {},                             103),
-    ((1,),          {'b': 2, 'c': 3},                 6),
-    ((1,),          {'b': 2},                       103),
-    ((),            {'a': 1, 'b': 2, 'c': 3},         6),
-    ((),            {'a': 1, 'b': 2},               103),
-    ((),            {'b': 2, 'c': 3},                15),
-    ((),            {'b': 2},                       112),
-])
+@pytest.mark.parametrize(
+    "args, kwargs, rv",
+    [
+        ((1, 2, 3), {}, 6),
+        ((1, 2), {"c": 3}, 6),
+        ((1, 2), {}, 103),
+        ((1,), {"b": 2, "c": 3}, 6),
+        ((1,), {"b": 2}, 103),
+        ((), {"a": 1, "b": 2, "c": 3}, 6),
+        ((), {"a": 1, "b": 2}, 103),
+        ((), {"b": 2, "c": 3}, 15),
+        ((), {"b": 2}, 112),
+    ],
+)
 def test_box_pass_ac(args, kwargs, rv, boxclass):
     testbox = boxclass()
-    testbox.put('a', 10)
-    testbox.put('c', 100)
+    testbox.put("a", 10)
+    testbox.put("c", 100)
 
-    @testbox.pass_('a')
-    @testbox.pass_('c')
+    @testbox.pass_("a")
+    @testbox.pass_("c")
     def fn(a, b, c):
         return a + b + c
 
     assert fn(*args, **kwargs) == rv
 
 
-@pytest.mark.parametrize('args, kwargs, rv', [
-    ((1, 2, 3),     {},                               6),
-    ((1, 2),        {'c': 3},                         6),
-    ((1, 2),        {},                            1003),
-    ((1,),          {'b': 2, 'c': 3},                 6),
-    ((1,),          {'b': 2},                      1003),
-    ((1,),          {'c': 3},                       104),
-    ((1,),          {},                            1101),
-    ((),            {'a': 1, 'b': 2, 'c': 3},         6),
-    ((),            {'a': 1, 'b': 2},              1003),
-    ((),            {'a': 1, 'c': 3},               104),
-    ((),            {'a': 1},                      1101),
-    ((),            {},                            1110),
-])
+@pytest.mark.parametrize(
+    "args, kwargs, rv",
+    [
+        ((1, 2, 3), {}, 6),
+        ((1, 2), {"c": 3}, 6),
+        ((1, 2), {}, 1003),
+        ((1,), {"b": 2, "c": 3}, 6),
+        ((1,), {"b": 2}, 1003),
+        ((1,), {"c": 3}, 104),
+        ((1,), {}, 1101),
+        ((), {"a": 1, "b": 2, "c": 3}, 6),
+        ((), {"a": 1, "b": 2}, 1003),
+        ((), {"a": 1, "c": 3}, 104),
+        ((), {"a": 1}, 1101),
+        ((), {}, 1110),
+    ],
+)
 def test_box_pass_abc(args, kwargs, rv, boxclass):
     testbox = boxclass()
-    testbox.put('a', 10)
-    testbox.put('b', 100)
-    testbox.put('c', 1000)
+    testbox.put("a", 10)
+    testbox.put("b", 100)
+    testbox.put("c", 1000)
 
-    @testbox.pass_('a')
-    @testbox.pass_('b')
-    @testbox.pass_('c')
+    @testbox.pass_("a")
+    @testbox.pass_("b")
+    @testbox.pass_("c")
     def fn(a, b, c):
         return a + b + c
 
     assert fn(*args, **kwargs) == rv
 
 
-@pytest.mark.parametrize('args, kwargs, rv', [
-    ((1, 2, 3),     {},                               6),
-    ((1, 2),        {'c': 3},                         6),
-    ((1,),          {'b': 2, 'c': 3},                 6),
-    ((1,),          {'c': 3},                        14),
-    ((),            {'a': 1, 'b': 2, 'c': 3},         6),
-    ((),            {'a': 1, 'c': 3},                14),
-])
+@pytest.mark.parametrize(
+    "args, kwargs, rv",
+    [
+        ((1, 2, 3), {}, 6),
+        ((1, 2), {"c": 3}, 6),
+        ((1,), {"b": 2, "c": 3}, 6),
+        ((1,), {"c": 3}, 14),
+        ((), {"a": 1, "b": 2, "c": 3}, 6),
+        ((), {"a": 1, "c": 3}, 14),
+    ],
+)
 def test_box_pass_d_as_b(args, kwargs, rv, boxclass):
     testbox = boxclass()
-    testbox.put('d', 10)
+    testbox.put("d", 10)
 
-    @testbox.pass_('d', as_='b')
+    @testbox.pass_("d", as_="b")
     def fn(a, b, c):
         return a + b + c
 
     assert fn(*args, **kwargs) == rv
 
 
-@pytest.mark.parametrize('args, kwargs, rv', [
-    ((1, ),         {},                               1),
-    ((),            {'x': 1},                         1),
-    ((),            {},                              42),
-])
+@pytest.mark.parametrize(
+    "args, kwargs, rv",
+    [
+        ((1,), {}, 1),
+        ((), {"x": 1}, 1),
+        ((), {}, 42),
+    ],
+)
 def test_box_pass_method(args, kwargs, rv, boxclass):
     testbox = boxclass()
-    testbox.put('x', 42)
+    testbox.put("x", 42)
 
     class Foo:
-        @testbox.pass_('x')
+        @testbox.pass_("x")
         def __init__(self, x):
             self.x = x
 
     assert Foo(*args, **kwargs).x == rv
 
 
-@pytest.mark.parametrize('args, kwargs, rv', [
-    ((0, ),         {},                              41),
-    ((),            {'x': 0},                        41),
-    ((),            {},                              42),
-])
+@pytest.mark.parametrize(
+    "args, kwargs, rv",
+    [
+        ((0,), {}, 41),
+        ((), {"x": 0}, 41),
+        ((), {}, 42),
+    ],
+)
 def test_box_pass_key_type(args, kwargs, rv, boxclass):
     class key:
         pass
@@ -348,7 +384,7 @@ def test_box_pass_key_type(args, kwargs, rv, boxclass):
     testbox = boxclass()
     testbox.put(key, 1)
 
-    @testbox.pass_(key, as_='x')
+    @testbox.pass_(key, as_="x")
     def fn(x):
         return x + 41
 
@@ -357,9 +393,9 @@ def test_box_pass_key_type(args, kwargs, rv, boxclass):
 
 def test_box_pass_unexpected_argument(boxclass):
     testbox = boxclass()
-    testbox.put('d', 10)
+    testbox.put("d", 10)
 
-    @testbox.pass_('d')
+    @testbox.pass_("d")
     def fn(a, b):
         return a + b
 
@@ -372,29 +408,32 @@ def test_box_pass_unexpected_argument(boxclass):
 def test_box_pass_keyerror(boxclass):
     testbox = boxclass()
 
-    @testbox.pass_('b')
+    @testbox.pass_("b")
     def fn(a, b):
         return a + b
 
     with pytest.raises(KeyError) as excinfo:
         fn(1)
 
-    excinfo.match('b')
+    excinfo.match("b")
 
 
 def test_box_pass_optimization(boxclass, request):
     testbox = boxclass()
-    testbox.put('a', 1)
-    testbox.put('b', 1)
-    testbox.put('d', 1)
+    testbox.put("a", 1)
+    testbox.put("b", 1)
+    testbox.put("d", 1)
 
-    @testbox.pass_('a')
-    @testbox.pass_('b')
-    @testbox.pass_('d', as_='c')
+    @testbox.pass_("a")
+    @testbox.pass_("b")
+    @testbox.pass_("d", as_="c")
     def fn(a, b, c):
-        backtrace = list(itertools.dropwhile(
-            lambda frame: frame[2] != request.function.__name__,
-            traceback.extract_stack()))
+        backtrace = list(
+            itertools.dropwhile(
+                lambda frame: frame[2] != request.function.__name__,
+                traceback.extract_stack(),
+            )
+        )
         return backtrace[1:-1]
 
     assert len(fn()) == 1
@@ -402,25 +441,29 @@ def test_box_pass_optimization(boxclass, request):
 
 def test_box_pass_optimization_complex(boxclass, request):
     testbox = boxclass()
-    testbox.put('a', 1)
-    testbox.put('b', 1)
-    testbox.put('c', 1)
-    testbox.put('d', 1)
+    testbox.put("a", 1)
+    testbox.put("b", 1)
+    testbox.put("c", 1)
+    testbox.put("d", 1)
 
     def passthrough(fn):
         def wrapper(*args, **kwargs):
             return fn(*args, **kwargs)
+
         return wrapper
 
-    @testbox.pass_('a')
-    @testbox.pass_('b')
+    @testbox.pass_("a")
+    @testbox.pass_("b")
     @passthrough
-    @testbox.pass_('c')
-    @testbox.pass_('d')
+    @testbox.pass_("c")
+    @testbox.pass_("d")
     def fn(a, b, c, d):
-        backtrace = list(itertools.dropwhile(
-            lambda frame: frame[2] != request.function.__name__,
-            traceback.extract_stack()))
+        backtrace = list(
+            itertools.dropwhile(
+                lambda frame: frame[2] != request.function.__name__,
+                traceback.extract_stack(),
+            )
+        )
         return backtrace[1:-1]
 
     assert len(fn()) == 3
@@ -430,35 +473,35 @@ def test_chainbox_put_changes_box():
     testbox = picobox.Box()
     testchainbox = picobox.ChainBox(testbox)
 
-    with pytest.raises(KeyError, match='the-key'):
-        testchainbox.get('the-key')
-    testchainbox.put('the-key', 42)
+    with pytest.raises(KeyError, match="the-key"):
+        testchainbox.get("the-key")
+    testchainbox.put("the-key", 42)
 
-    assert testbox.get('the-key') == 42
+    assert testbox.get("the-key") == 42
 
 
 def test_chainbox_get_chained():
     testbox_a = picobox.Box()
-    testbox_a.put('the-key', 42)
+    testbox_a.put("the-key", 42)
 
     testbox_b = picobox.Box()
-    testbox_b.put('the-key', 13)
-    testbox_b.put('the-pin', 12)
+    testbox_b.put("the-key", 13)
+    testbox_b.put("the-pin", 12)
 
     testchainbox = picobox.ChainBox(testbox_a, testbox_b)
 
-    assert testchainbox.get('the-key') == 42
-    assert testchainbox.get('the-pin') == 12
+    assert testchainbox.get("the-key") == 42
+    assert testchainbox.get("the-pin") == 12
 
 
 def test_chainbox_isinstance_box():
     assert isinstance(picobox.ChainBox(), picobox.Box)
 
 
-@pytest.mark.parametrize('name', [
-    name
-    for name, _ in inspect.getmembers(picobox.Box) if not name.startswith('_')
-])
+@pytest.mark.parametrize(
+    "name",
+    [name for name, _ in inspect.getmembers(picobox.Box) if not name.startswith("_")],
+)
 def test_chainbox_box_interface(name):
     boxsignature = inspect.signature(getattr(picobox.Box(), name))
     chainboxsignature = inspect.signature(getattr(picobox.ChainBox(), name))

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -6,53 +6,55 @@ import pytest
 import picobox
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def singleton():
     return picobox.singleton()
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def threadlocal():
     return picobox.threadlocal()
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def contextvars():
-    pytest.importorskip('contextvars')
+    pytest.importorskip("contextvars")
     return picobox.contextvars()
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def noscope():
     return picobox.noscope()
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def exec_thread():
     """Run a given callback in a separate OS thread."""
+
     def executor(callback, *args, **kwargs):
         closure = {}
 
         def target():
             try:
-                closure['ret'] = callback(*args, **kwargs)
+                closure["ret"] = callback(*args, **kwargs)
             except Exception as e:
-                closure['exc'] = e
+                closure["exc"] = e
 
         worker = threading.Thread(target=target)
         worker.start()
         worker.join()
 
-        if 'exc' in closure:
-            raise closure['exc']
-        return closure['ret']
+        if "exc" in closure:
+            raise closure["exc"]
+        return closure["ret"]
+
     return executor
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def exec_coroutine(request):
     """Run a given coroutine function in a separate event loop."""
-    asyncio = pytest.importorskip('asyncio')
+    asyncio = pytest.importorskip("asyncio")
     loop = asyncio.new_event_loop()
     request.addfinalizer(loop.close)
 
@@ -60,24 +62,27 @@ def exec_coroutine(request):
         if not asyncio.iscoroutinefunction(coroutine_function):
             coroutine_function = asyncio.coroutine(coroutine_function)
         return loop.run_until_complete(coroutine_function(*args, **kwargs))
+
     return executor
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def exec_context():
     """Run a given callback in a separate context (PEP 567)."""
+
     def executor(callback, *args, **kwargs):
         import contextvars
+
         context = contextvars.copy_context()
         return context.run(callback, *args, **kwargs)
 
-    pytest.importorskip('contextvars')
+    pytest.importorskip("contextvars")
     return executor
 
 
 def test_scope_contextvars_attribute_error(monkeypatch):
     try:
-        __import__('contextvars')
+        __import__("contextvars")
         pytest.skip("could import 'contextvars'")
     except ImportError:
         pass
@@ -86,11 +91,14 @@ def test_scope_contextvars_attribute_error(monkeypatch):
         picobox.contextvars
 
 
-@pytest.mark.parametrize('scopename', [
-    'singleton',
-    'threadlocal',
-    'contextvars',
-])
+@pytest.mark.parametrize(
+    "scopename",
+    [
+        "singleton",
+        "threadlocal",
+        "contextvars",
+    ],
+)
 def test_scope_set(request, scopename, supported_key, supported_value):
     scope = request.getfixturevalue(scopename)
 
@@ -106,28 +114,34 @@ def test_scope_set_noscope(supported_key, supported_value):
         scope.get(supported_key)
 
 
-@pytest.mark.parametrize('scopename', [
-    'singleton',
-    'threadlocal',
-    'contextvars',
-])
+@pytest.mark.parametrize(
+    "scopename",
+    [
+        "singleton",
+        "threadlocal",
+        "contextvars",
+    ],
+)
 def test_scope_set_overwrite(request, scopename):
     scope = request.getfixturevalue(scopename)
     value = object()
 
-    scope.set('the-key', value)
-    assert scope.get('the-key') is value
+    scope.set("the-key", value)
+    assert scope.get("the-key") is value
 
-    scope.set('the-key', 'overwrite')
-    assert scope.get('the-key') == 'overwrite'
+    scope.set("the-key", "overwrite")
+    assert scope.get("the-key") == "overwrite"
 
 
-@pytest.mark.parametrize('scopename', [
-    'singleton',
-    'threadlocal',
-    'contextvars',
-    'noscope',
-])
+@pytest.mark.parametrize(
+    "scopename",
+    [
+        "singleton",
+        "threadlocal",
+        "contextvars",
+        "noscope",
+    ],
+)
 def test_scope_get_keyerror(request, scopename, supported_key):
     scope = request.getfixturevalue(scopename)
 
@@ -135,11 +149,14 @@ def test_scope_get_keyerror(request, scopename, supported_key):
         scope.get(supported_key)
 
 
-@pytest.mark.parametrize('scopename', [
-    'singleton',
-    'threadlocal',
-    'contextvars',
-])
+@pytest.mark.parametrize(
+    "scopename",
+    [
+        "singleton",
+        "threadlocal",
+        "contextvars",
+    ],
+)
 def test_scope_state_not_leaked(request, scopename):
     scope_a = request.getfixturevalue(scopename)
     value_a = object()
@@ -147,114 +164,129 @@ def test_scope_state_not_leaked(request, scopename):
     scope_b = type(scope_a)()
     value_b = object()
 
-    scope_a.set('the-key', value_a)
-    assert scope_a.get('the-key') is value_a
+    scope_a.set("the-key", value_a)
+    assert scope_a.get("the-key") is value_a
 
-    with pytest.raises(KeyError, match='the-key'):
-        scope_b.get('the-key')
+    with pytest.raises(KeyError, match="the-key"):
+        scope_b.get("the-key")
 
-    scope_b.set('the-key', value_b)
-    assert scope_b.get('the-key') is value_b
+    scope_b.set("the-key", value_b)
+    assert scope_b.get("the-key") is value_b
 
-    scope_a.set('the-key', value_a)
-    assert scope_a.get('the-key') is value_a
+    scope_a.set("the-key", value_a)
+    assert scope_a.get("the-key") is value_a
 
 
-@pytest.mark.parametrize('scopename, executor', [
-    ('singleton',    'exec_thread'),
-    ('singleton',    'exec_coroutine'),
-    ('singleton',    'exec_context'),
-    ('threadlocal',  'exec_coroutine'),
-    ('threadlocal',  'exec_context'),
-])
+@pytest.mark.parametrize(
+    "scopename, executor",
+    [
+        ("singleton", "exec_thread"),
+        ("singleton", "exec_coroutine"),
+        ("singleton", "exec_context"),
+        ("threadlocal", "exec_coroutine"),
+        ("threadlocal", "exec_context"),
+    ],
+)
 def test_scope_value_shared(request, scopename, executor):
     scope = request.getfixturevalue(scopename)
     value = object()
     exec_ = request.getfixturevalue(executor)
 
-    exec_(scope.set, 'the-key', value)
-    assert exec_(scope.get, 'the-key') is value
+    exec_(scope.set, "the-key", value)
+    assert exec_(scope.get, "the-key") is value
 
 
-@pytest.mark.parametrize('scopename, executor', [
-    ('threadlocal',  'exec_thread'),
-    ('contextvars',  'exec_thread'),
-    ('contextvars',  'exec_coroutine'),
-    ('contextvars',  'exec_context'),
-    ('noscope',      'exec_thread'),
-    ('noscope',      'exec_coroutine'),
-    ('noscope',      'exec_context'),
-])
+@pytest.mark.parametrize(
+    "scopename, executor",
+    [
+        ("threadlocal", "exec_thread"),
+        ("contextvars", "exec_thread"),
+        ("contextvars", "exec_coroutine"),
+        ("contextvars", "exec_context"),
+        ("noscope", "exec_thread"),
+        ("noscope", "exec_coroutine"),
+        ("noscope", "exec_context"),
+    ],
+)
 def test_scope_value_not_shared(request, scopename, executor):
     scope = request.getfixturevalue(scopename)
     value = object()
     exec_ = request.getfixturevalue(executor)
 
-    exec_(scope.set, 'the-key', value)
+    exec_(scope.set, "the-key", value)
 
-    with pytest.raises(KeyError, match='the-key'):
-        exec_(scope.get, 'the-key')
+    with pytest.raises(KeyError, match="the-key"):
+        exec_(scope.get, "the-key")
 
 
-@pytest.mark.parametrize('scopename, executor', [
-    ('singleton',    'exec_thread'),
-    ('singleton',    'exec_coroutine'),
-    ('singleton',    'exec_context'),
-    ('threadlocal',  'exec_thread'),
-    ('threadlocal',  'exec_coroutine'),
-    ('threadlocal',  'exec_context'),
-    ('contextvars',  'exec_thread'),
-    ('contextvars',  'exec_coroutine'),
-    ('contextvars',  'exec_context'),
-])
+@pytest.mark.parametrize(
+    "scopename, executor",
+    [
+        ("singleton", "exec_thread"),
+        ("singleton", "exec_coroutine"),
+        ("singleton", "exec_context"),
+        ("threadlocal", "exec_thread"),
+        ("threadlocal", "exec_coroutine"),
+        ("threadlocal", "exec_context"),
+        ("contextvars", "exec_thread"),
+        ("contextvars", "exec_coroutine"),
+        ("contextvars", "exec_context"),
+    ],
+)
 def test_scope_value_downstack_shared(request, scopename, executor):
     scope = request.getfixturevalue(scopename)
     value = object()
     exec_ = request.getfixturevalue(executor)
 
     def caller():
-        scope.set('the-key', value)
+        scope.set("the-key", value)
         return callee()
 
     def callee():
-        return scope.get('the-key')
+        return scope.get("the-key")
 
     assert exec_(caller) is value
 
 
-@pytest.mark.parametrize('scopename, executor', [
-    ('noscope',      'exec_thread'),
-    ('noscope',      'exec_coroutine'),
-    ('noscope',      'exec_context'),
-])
+@pytest.mark.parametrize(
+    "scopename, executor",
+    [
+        ("noscope", "exec_thread"),
+        ("noscope", "exec_coroutine"),
+        ("noscope", "exec_context"),
+    ],
+)
 def test_scope_value_downstack_not_shared(request, scopename, executor):
     scope = request.getfixturevalue(scopename)
     value = object()
     exec_ = request.getfixturevalue(executor)
 
     def caller():
-        scope.set('the-key', value)
+        scope.set("the-key", value)
         return callee()
 
     def callee():
-        return scope.get('the-key')
+        return scope.get("the-key")
 
-    with pytest.raises(KeyError, match='the-key'):
+    with pytest.raises(KeyError, match="the-key"):
         exec_(caller)
 
 
-@pytest.mark.parametrize('scopename, executor', [
-    ('threadlocal',  'exec_thread'),
-    ('contextvars',  'exec_thread'),
-    ('contextvars',  'exec_coroutine'),
-    ('contextvars',  'exec_context'),
-])
+@pytest.mark.parametrize(
+    "scopename, executor",
+    [
+        ("threadlocal", "exec_thread"),
+        ("contextvars", "exec_thread"),
+        ("contextvars", "exec_coroutine"),
+        ("contextvars", "exec_context"),
+    ],
+)
 def test_scope_not_leaked(request, scopename, executor):
     scope = request.getfixturevalue(scopename)
     exec_ = request.getfixturevalue(executor)
 
-    scope.set('a-key', 'a-value')
-    exec_(scope.set, 'the-key', 'the-value')
+    scope.set("a-key", "a-value")
+    exec_(scope.set, "the-key", "the-value")
 
-    with pytest.raises(KeyError, match='the-key'):
-        scope.get('the-key')
+    with pytest.raises(KeyError, match="the-key"):
+        scope.get("the-key")

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -16,27 +16,27 @@ def test_box_put_key(boxclass, teststack, supported_key):
     testbox = boxclass()
 
     with teststack.push(testbox):
-        teststack.put(supported_key, 'the-value')
+        teststack.put(supported_key, "the-value")
 
-    assert testbox.get(supported_key) == 'the-value'
+    assert testbox.get(supported_key) == "the-value"
 
 
 def test_box_put_value(boxclass, teststack, supported_value):
     testbox = boxclass()
 
     with teststack.push(testbox):
-        teststack.put('the-key', supported_value)
+        teststack.put("the-key", supported_value)
 
-    assert testbox.get('the-key') is supported_value
+    assert testbox.get("the-key") is supported_value
 
 
 def test_box_put_factory(boxclass, teststack):
     testbox = boxclass()
 
     with teststack.push(testbox):
-        teststack.put('the-key', factory=object)
+        teststack.put("the-key", factory=object)
 
-    objects = [testbox.get('the-key') for _ in range(10)]
+    objects = [testbox.get("the-key") for _ in range(10)]
 
     assert len(objects) == 10
     assert len(set(map(id, objects))) == 10
@@ -46,9 +46,9 @@ def test_box_put_factory_singleton_scope(boxclass, teststack):
     testbox = boxclass()
 
     with teststack.push(testbox):
-        teststack.put('the-key', factory=object, scope=picobox.singleton)
+        teststack.put("the-key", factory=object, scope=picobox.singleton)
 
-    objects = [testbox.get('the-key') for _ in range(10)]
+    objects = [testbox.get("the-key") for _ in range(10)]
 
     assert len(objects) == 10
     assert len(set(map(id, objects))) == 1
@@ -57,15 +57,15 @@ def test_box_put_factory_singleton_scope(boxclass, teststack):
 def test_box_put_factory_dependency(boxclass, teststack):
     testbox = boxclass()
 
-    @teststack.pass_('a')
+    @teststack.pass_("a")
     def fn(a):
         return a + 1
 
     with teststack.push(testbox):
-        teststack.put('a', 13)
-        teststack.put('b', factory=fn)
+        teststack.put("a", 13)
+        teststack.put("b", factory=fn)
 
-        assert teststack.get('b') == 14
+        assert teststack.get("b") == 14
 
 
 def test_box_put_value_and_factory(boxclass, teststack):
@@ -73,7 +73,7 @@ def test_box_put_value_and_factory(boxclass, teststack):
 
     with teststack.push(testbox):
         with pytest.raises(ValueError) as excinfo:
-            teststack.put('the-key', 42, factory=object)
+            teststack.put("the-key", 42, factory=object)
     excinfo.match("either 'value' or 'factory'/'scope' pair must be passed")
 
 
@@ -82,32 +82,33 @@ def test_box_put_value_and_scope(boxclass, teststack):
 
     with teststack.push(testbox):
         with pytest.raises(ValueError) as excinfo:
-            teststack.put('the-key', 42, scope=picobox.threadlocal)
+            teststack.put("the-key", 42, scope=picobox.threadlocal)
     excinfo.match("either 'value' or 'factory'/'scope' pair must be passed")
 
 
 def test_box_put_runtimeerror(boxclass, teststack):
     with pytest.raises(RuntimeError) as excinfo:
-        teststack.put('the-key', object())
+        teststack.put("the-key", object())
 
     assert str(excinfo.value) == (
-        'No boxes found on the stack, please `.push()` a box first.')
+        "No boxes found on the stack, please `.push()` a box first."
+    )
 
 
 def test_box_get_value(boxclass, teststack, supported_value):
     testbox = boxclass()
-    testbox.put('the-key', supported_value)
+    testbox.put("the-key", supported_value)
 
     with teststack.push(testbox):
-        assert teststack.get('the-key') is supported_value
+        assert teststack.get("the-key") is supported_value
 
 
 def test_box_get_keyerror(boxclass, teststack):
     testbox = boxclass()
 
     with teststack.push(testbox):
-        with pytest.raises(KeyError, match='the-key'):
-            teststack.get('the-key')
+        with pytest.raises(KeyError, match="the-key"):
+            teststack.get("the-key")
 
 
 def test_box_get_default(boxclass, teststack):
@@ -115,80 +116,87 @@ def test_box_get_default(boxclass, teststack):
     sentinel = object()
 
     with teststack.push(testbox):
-        assert teststack.get('the-key', sentinel) is sentinel
+        assert teststack.get("the-key", sentinel) is sentinel
 
 
-@pytest.mark.parametrize('kwargs', [
-    {},
-    {'chain': False},
-])
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"chain": False},
+    ],
+)
 def test_box_get_from_top(boxclass, teststack, kwargs):
     testbox_a = boxclass()
-    testbox_a.put('the-key', 'a')
-    testbox_a.put('the-pin', 'a')
+    testbox_a.put("the-key", "a")
+    testbox_a.put("the-pin", "a")
 
     testbox_b = boxclass()
-    testbox_b.put('the-key', 'b')
+    testbox_b.put("the-key", "b")
 
     with teststack.push(testbox_a):
-        assert teststack.get('the-key') == 'a'
-        assert teststack.get('the-pin') == 'a'
+        assert teststack.get("the-key") == "a"
+        assert teststack.get("the-pin") == "a"
 
         with teststack.push(testbox_b, **kwargs):
-            assert teststack.get('the-key') == 'b'
+            assert teststack.get("the-key") == "b"
 
-            with pytest.raises(KeyError, match='the-pin'):
-                teststack.get('the-pin')
+            with pytest.raises(KeyError, match="the-pin"):
+                teststack.get("the-pin")
 
-        assert teststack.get('the-key') == 'a'
-        assert teststack.get('the-pin') == 'a'
+        assert teststack.get("the-key") == "a"
+        assert teststack.get("the-pin") == "a"
 
 
 def test_box_get_from_top_chain(boxclass, teststack):
     testbox_a = boxclass()
-    testbox_a.put('the-key', 'a')
-    testbox_a.put('the-pin', 'a')
+    testbox_a.put("the-key", "a")
+    testbox_a.put("the-pin", "a")
 
     testbox_b = boxclass()
-    testbox_b.put('the-key', 'b')
+    testbox_b.put("the-key", "b")
 
     testbox_c = boxclass()
-    testbox_c.put('the-tip', 'c')
+    testbox_c.put("the-tip", "c")
 
     with teststack.push(testbox_a):
-        assert teststack.get('the-key') == 'a'
-        assert teststack.get('the-pin') == 'a'
+        assert teststack.get("the-key") == "a"
+        assert teststack.get("the-pin") == "a"
 
         with teststack.push(testbox_b, chain=True):
-            assert teststack.get('the-key') == 'b'
-            assert teststack.get('the-pin') == 'a'
+            assert teststack.get("the-key") == "b"
+            assert teststack.get("the-pin") == "a"
 
             with teststack.push(testbox_c, chain=True):
-                assert teststack.get('the-tip') == 'c'
-                assert teststack.get('the-key') == 'b'
-                assert teststack.get('the-pin') == 'a'
+                assert teststack.get("the-tip") == "c"
+                assert teststack.get("the-key") == "b"
+                assert teststack.get("the-pin") == "a"
 
 
 def test_box_get_runtimeerror(teststack):
     with pytest.raises(RuntimeError) as excinfo:
-        teststack.get('the-key')
+        teststack.get("the-key")
 
     assert str(excinfo.value) == (
-        'No boxes found on the stack, please `.push()` a box first.')
+        "No boxes found on the stack, please `.push()` a box first."
+    )
 
 
-@pytest.mark.parametrize('args, kwargs, rv', [
-    ((1, 2, 3),     {},                               6),
-    ((1, 2),        {'c': 3},                         6),
-    ((1,),          {'b': 2, 'c': 3},                 6),
-    ((),            {'a': 1, 'b': 2, 'c': 3},         6),
-    ((),            {'b': 2, 'c': 3},                15),
-])
+@pytest.mark.parametrize(
+    "args, kwargs, rv",
+    [
+        ((1, 2, 3), {}, 6),
+        ((1, 2), {"c": 3}, 6),
+        ((1,), {"b": 2, "c": 3}, 6),
+        ((), {"a": 1, "b": 2, "c": 3}, 6),
+        ((), {"b": 2, "c": 3}, 15),
+    ],
+)
 def test_box_pass_a(boxclass, teststack, args, kwargs, rv):
     testbox = boxclass()
-    testbox.put('a', 10)
+    testbox.put("a", 10)
 
-    @teststack.pass_('a')
+    @teststack.pass_("a")
     def fn(a, b, c):
         return a + b + c
 
@@ -196,19 +204,22 @@ def test_box_pass_a(boxclass, teststack, args, kwargs, rv):
         assert fn(*args, **kwargs) == rv
 
 
-@pytest.mark.parametrize('args, kwargs, rv', [
-    ((1, 2, 3),     {},                               6),
-    ((1, 2),        {'c': 3},                         6),
-    ((1,),          {'b': 2, 'c': 3},                 6),
-    ((1,),          {'c': 3},                        14),
-    ((),            {'a': 1, 'b': 2, 'c': 3},         6),
-    ((),            {'a': 1, 'c': 3},                14),
-])
+@pytest.mark.parametrize(
+    "args, kwargs, rv",
+    [
+        ((1, 2, 3), {}, 6),
+        ((1, 2), {"c": 3}, 6),
+        ((1,), {"b": 2, "c": 3}, 6),
+        ((1,), {"c": 3}, 14),
+        ((), {"a": 1, "b": 2, "c": 3}, 6),
+        ((), {"a": 1, "c": 3}, 14),
+    ],
+)
 def test_box_pass_b(boxclass, teststack, args, kwargs, rv):
     testbox = boxclass()
-    testbox.put('b', 10)
+    testbox.put("b", 10)
 
-    @teststack.pass_('b')
+    @teststack.pass_("b")
     def fn(a, b, c):
         return a + b + c
 
@@ -216,20 +227,23 @@ def test_box_pass_b(boxclass, teststack, args, kwargs, rv):
         assert fn(*args, **kwargs) == rv
 
 
-@pytest.mark.parametrize('args, kwargs, rv', [
-    ((1, 2, 3),     {},                               6),
-    ((1, 2),        {'c': 3},                         6),
-    ((1, 2),        {},                              13),
-    ((1,),          {'b': 2, 'c': 3},                 6),
-    ((1,),          {'b': 2},                        13),
-    ((),            {'a': 1, 'b': 2, 'c': 3},         6),
-    ((),            {'a': 1, 'b': 2},                13),
-])
+@pytest.mark.parametrize(
+    "args, kwargs, rv",
+    [
+        ((1, 2, 3), {}, 6),
+        ((1, 2), {"c": 3}, 6),
+        ((1, 2), {}, 13),
+        ((1,), {"b": 2, "c": 3}, 6),
+        ((1,), {"b": 2}, 13),
+        ((), {"a": 1, "b": 2, "c": 3}, 6),
+        ((), {"a": 1, "b": 2}, 13),
+    ],
+)
 def test_box_pass_c(boxclass, teststack, args, kwargs, rv):
     testbox = boxclass()
-    testbox.put('c', 10)
+    testbox.put("c", 10)
 
-    @teststack.pass_('c')
+    @teststack.pass_("c")
     def fn(a, b, c):
         return a + b + c
 
@@ -237,20 +251,23 @@ def test_box_pass_c(boxclass, teststack, args, kwargs, rv):
         assert fn(*args, **kwargs) == rv
 
 
-@pytest.mark.parametrize('args, kwargs, rv', [
-    ((1, 2, 3),     {},                               6),
-    ((1, 2),        {'c': 3},                         6),
-    ((1, 2),        {},                              13),
-    ((1,),          {'b': 2, 'c': 3},                 6),
-    ((1,),          {'b': 2},                        13),
-    ((),            {'a': 1, 'b': 2, 'c': 3},         6),
-    ((),            {'a': 1, 'b': 2},                13),
-])
+@pytest.mark.parametrize(
+    "args, kwargs, rv",
+    [
+        ((1, 2, 3), {}, 6),
+        ((1, 2), {"c": 3}, 6),
+        ((1, 2), {}, 13),
+        ((1,), {"b": 2, "c": 3}, 6),
+        ((1,), {"b": 2}, 13),
+        ((), {"a": 1, "b": 2, "c": 3}, 6),
+        ((), {"a": 1, "b": 2}, 13),
+    ],
+)
 def test_box_pass_c_default(boxclass, teststack, args, kwargs, rv):
     testbox = boxclass()
-    testbox.put('c', 10)
+    testbox.put("c", 10)
 
-    @teststack.pass_('c')
+    @teststack.pass_("c")
     def fn(a, b, c=20):
         return a + b + c
 
@@ -258,23 +275,26 @@ def test_box_pass_c_default(boxclass, teststack, args, kwargs, rv):
         assert fn(*args, **kwargs) == rv
 
 
-@pytest.mark.parametrize('args, kwargs, rv', [
-    ((1, 2, 3),     {},                               6),
-    ((1, 2),        {'c': 3},                         6),
-    ((1,),          {'b': 2, 'c': 3},                 6),
-    ((1,),          {'c': 3},                       104),
-    ((),            {'a': 1, 'b': 2, 'c': 3},         6),
-    ((),            {'a': 1, 'c': 3},               104),
-    ((),            {'b': 2, 'c': 3},                15),
-    ((),            {'c': 3},                       113),
-])
+@pytest.mark.parametrize(
+    "args, kwargs, rv",
+    [
+        ((1, 2, 3), {}, 6),
+        ((1, 2), {"c": 3}, 6),
+        ((1,), {"b": 2, "c": 3}, 6),
+        ((1,), {"c": 3}, 104),
+        ((), {"a": 1, "b": 2, "c": 3}, 6),
+        ((), {"a": 1, "c": 3}, 104),
+        ((), {"b": 2, "c": 3}, 15),
+        ((), {"c": 3}, 113),
+    ],
+)
 def test_box_pass_ab(boxclass, teststack, args, kwargs, rv):
     testbox = boxclass()
-    testbox.put('a', 10)
-    testbox.put('b', 100)
+    testbox.put("a", 10)
+    testbox.put("b", 100)
 
-    @teststack.pass_('a')
-    @teststack.pass_('b')
+    @teststack.pass_("a")
+    @teststack.pass_("b")
     def fn(a, b, c):
         return a + b + c
 
@@ -282,26 +302,29 @@ def test_box_pass_ab(boxclass, teststack, args, kwargs, rv):
         assert fn(*args, **kwargs) == rv
 
 
-@pytest.mark.parametrize('args, kwargs, rv', [
-    ((1, 2, 3),     {},                               6),
-    ((1, 2),        {'c': 3},                         6),
-    ((1, 2),        {},                             103),
-    ((1,),          {'b': 2, 'c': 3},                 6),
-    ((1,),          {'b': 2},                       103),
-    ((1,),          {'c': 3},                        14),
-    ((1,),          {},                             111),
-    ((),            {'a': 1, 'b': 2, 'c': 3},         6),
-    ((),            {'a': 1, 'b': 2},               103),
-    ((),            {'a': 1, 'c': 3},                14),
-    ((),            {'a': 1},                       111),
-])
+@pytest.mark.parametrize(
+    "args, kwargs, rv",
+    [
+        ((1, 2, 3), {}, 6),
+        ((1, 2), {"c": 3}, 6),
+        ((1, 2), {}, 103),
+        ((1,), {"b": 2, "c": 3}, 6),
+        ((1,), {"b": 2}, 103),
+        ((1,), {"c": 3}, 14),
+        ((1,), {}, 111),
+        ((), {"a": 1, "b": 2, "c": 3}, 6),
+        ((), {"a": 1, "b": 2}, 103),
+        ((), {"a": 1, "c": 3}, 14),
+        ((), {"a": 1}, 111),
+    ],
+)
 def test_box_pass_bc(boxclass, teststack, args, kwargs, rv):
     testbox = boxclass()
-    testbox.put('b', 10)
-    testbox.put('c', 100)
+    testbox.put("b", 10)
+    testbox.put("c", 100)
 
-    @teststack.pass_('b')
-    @teststack.pass_('c')
+    @teststack.pass_("b")
+    @teststack.pass_("c")
     def fn(a, b, c):
         return a + b + c
 
@@ -309,24 +332,27 @@ def test_box_pass_bc(boxclass, teststack, args, kwargs, rv):
         assert fn(*args, **kwargs) == rv
 
 
-@pytest.mark.parametrize('args, kwargs, rv', [
-    ((1, 2, 3),     {},                               6),
-    ((1, 2),        {'c': 3},                         6),
-    ((1, 2),        {},                             103),
-    ((1,),          {'b': 2, 'c': 3},                 6),
-    ((1,),          {'b': 2},                       103),
-    ((),            {'a': 1, 'b': 2, 'c': 3},         6),
-    ((),            {'a': 1, 'b': 2},               103),
-    ((),            {'b': 2, 'c': 3},                15),
-    ((),            {'b': 2},                       112),
-])
+@pytest.mark.parametrize(
+    "args, kwargs, rv",
+    [
+        ((1, 2, 3), {}, 6),
+        ((1, 2), {"c": 3}, 6),
+        ((1, 2), {}, 103),
+        ((1,), {"b": 2, "c": 3}, 6),
+        ((1,), {"b": 2}, 103),
+        ((), {"a": 1, "b": 2, "c": 3}, 6),
+        ((), {"a": 1, "b": 2}, 103),
+        ((), {"b": 2, "c": 3}, 15),
+        ((), {"b": 2}, 112),
+    ],
+)
 def test_box_pass_ac(boxclass, teststack, args, kwargs, rv):
     testbox = boxclass()
-    testbox.put('a', 10)
-    testbox.put('c', 100)
+    testbox.put("a", 10)
+    testbox.put("c", 100)
 
-    @teststack.pass_('a')
-    @teststack.pass_('c')
+    @teststack.pass_("a")
+    @teststack.pass_("c")
     def fn(a, b, c):
         return a + b + c
 
@@ -334,29 +360,32 @@ def test_box_pass_ac(boxclass, teststack, args, kwargs, rv):
         assert fn(*args, **kwargs) == rv
 
 
-@pytest.mark.parametrize('args, kwargs, rv', [
-    ((1, 2, 3),     {},                               6),
-    ((1, 2),        {'c': 3},                         6),
-    ((1, 2),        {},                            1003),
-    ((1,),          {'b': 2, 'c': 3},                 6),
-    ((1,),          {'b': 2},                      1003),
-    ((1,),          {'c': 3},                       104),
-    ((1,),          {},                            1101),
-    ((),            {'a': 1, 'b': 2, 'c': 3},         6),
-    ((),            {'a': 1, 'b': 2},              1003),
-    ((),            {'a': 1, 'c': 3},               104),
-    ((),            {'a': 1},                      1101),
-    ((),            {},                            1110),
-])
+@pytest.mark.parametrize(
+    "args, kwargs, rv",
+    [
+        ((1, 2, 3), {}, 6),
+        ((1, 2), {"c": 3}, 6),
+        ((1, 2), {}, 1003),
+        ((1,), {"b": 2, "c": 3}, 6),
+        ((1,), {"b": 2}, 1003),
+        ((1,), {"c": 3}, 104),
+        ((1,), {}, 1101),
+        ((), {"a": 1, "b": 2, "c": 3}, 6),
+        ((), {"a": 1, "b": 2}, 1003),
+        ((), {"a": 1, "c": 3}, 104),
+        ((), {"a": 1}, 1101),
+        ((), {}, 1110),
+    ],
+)
 def test_box_pass_abc(boxclass, teststack, args, kwargs, rv):
     testbox = boxclass()
-    testbox.put('a', 10)
-    testbox.put('b', 100)
-    testbox.put('c', 1000)
+    testbox.put("a", 10)
+    testbox.put("b", 100)
+    testbox.put("c", 1000)
 
-    @teststack.pass_('a')
-    @teststack.pass_('b')
-    @teststack.pass_('c')
+    @teststack.pass_("a")
+    @teststack.pass_("b")
+    @teststack.pass_("c")
     def fn(a, b, c):
         return a + b + c
 
@@ -364,19 +393,22 @@ def test_box_pass_abc(boxclass, teststack, args, kwargs, rv):
         assert fn(*args, **kwargs) == rv
 
 
-@pytest.mark.parametrize('args, kwargs, rv', [
-    ((1, 2, 3),     {},                               6),
-    ((1, 2),        {'c': 3},                         6),
-    ((1,),          {'b': 2, 'c': 3},                 6),
-    ((1,),          {'c': 3},                        14),
-    ((),            {'a': 1, 'b': 2, 'c': 3},         6),
-    ((),            {'a': 1, 'c': 3},                14),
-])
+@pytest.mark.parametrize(
+    "args, kwargs, rv",
+    [
+        ((1, 2, 3), {}, 6),
+        ((1, 2), {"c": 3}, 6),
+        ((1,), {"b": 2, "c": 3}, 6),
+        ((1,), {"c": 3}, 14),
+        ((), {"a": 1, "b": 2, "c": 3}, 6),
+        ((), {"a": 1, "c": 3}, 14),
+    ],
+)
 def test_box_pass_d_as_b(boxclass, teststack, args, kwargs, rv):
     testbox = boxclass()
-    testbox.put('d', 10)
+    testbox.put("d", 10)
 
-    @teststack.pass_('d', as_='b')
+    @teststack.pass_("d", as_="b")
     def fn(a, b, c):
         return a + b + c
 
@@ -384,17 +416,20 @@ def test_box_pass_d_as_b(boxclass, teststack, args, kwargs, rv):
         assert fn(*args, **kwargs) == rv
 
 
-@pytest.mark.parametrize('args, kwargs, rv', [
-    ((1, ),         {},                               1),
-    ((),            {'x': 1},                         1),
-    ((),            {},                              42),
-])
+@pytest.mark.parametrize(
+    "args, kwargs, rv",
+    [
+        ((1,), {}, 1),
+        ((), {"x": 1}, 1),
+        ((), {}, 42),
+    ],
+)
 def test_box_pass_method(boxclass, teststack, args, kwargs, rv):
     testbox = boxclass()
-    testbox.put('x', 42)
+    testbox.put("x", 42)
 
     class Foo:
-        @teststack.pass_('x')
+        @teststack.pass_("x")
         def __init__(self, x):
             self.x = x
 
@@ -402,11 +437,14 @@ def test_box_pass_method(boxclass, teststack, args, kwargs, rv):
         assert Foo(*args, **kwargs).x == rv
 
 
-@pytest.mark.parametrize('args, kwargs, rv', [
-    ((0, ),         {},                              41),
-    ((),            {'x': 0},                        41),
-    ((),            {},                              42),
-])
+@pytest.mark.parametrize(
+    "args, kwargs, rv",
+    [
+        ((0,), {}, 41),
+        ((), {"x": 0}, 41),
+        ((), {}, 42),
+    ],
+)
 def test_box_pass_key_type(boxclass, teststack, args, kwargs, rv):
     class key:
         pass
@@ -414,7 +452,7 @@ def test_box_pass_key_type(boxclass, teststack, args, kwargs, rv):
     testbox = boxclass()
     testbox.put(key, 1)
 
-    @testbox.pass_(key, as_='x')
+    @testbox.pass_(key, as_="x")
     def fn(x):
         return x + 41
 
@@ -424,9 +462,9 @@ def test_box_pass_key_type(boxclass, teststack, args, kwargs, rv):
 
 def test_box_pass_unexpected_argument(boxclass, teststack):
     testbox = boxclass()
-    testbox.put('d', 10)
+    testbox.put("d", 10)
 
-    @teststack.pass_('d')
+    @teststack.pass_("d")
     def fn(a, b):
         return a + b
 
@@ -440,17 +478,17 @@ def test_box_pass_unexpected_argument(boxclass, teststack):
 def test_box_pass_keyerror(boxclass, teststack):
     testbox = boxclass()
 
-    @teststack.pass_('b')
+    @teststack.pass_("b")
     def fn(a, b):
         return a + b
 
     with teststack.push(testbox):
-        with pytest.raises(KeyError, match='b'):
+        with pytest.raises(KeyError, match="b"):
             fn(1)
 
 
 def test_box_pass_runtimeerror(teststack):
-    @teststack.pass_('a')
+    @teststack.pass_("a")
     def fn(a):
         return a
 
@@ -458,22 +496,26 @@ def test_box_pass_runtimeerror(teststack):
         fn()
 
     assert str(excinfo.value) == (
-        'No boxes found on the stack, please `.push()` a box first.')
+        "No boxes found on the stack, please `.push()` a box first."
+    )
 
 
 def test_box_pass_optimization(boxclass, teststack, request):
     testbox = boxclass()
-    testbox.put('a', 1)
-    testbox.put('b', 1)
-    testbox.put('d', 1)
+    testbox.put("a", 1)
+    testbox.put("b", 1)
+    testbox.put("d", 1)
 
-    @teststack.pass_('a')
-    @teststack.pass_('b')
-    @teststack.pass_('d', as_='c')
+    @teststack.pass_("a")
+    @teststack.pass_("b")
+    @teststack.pass_("d", as_="c")
     def fn(a, b, c):
-        backtrace = list(itertools.dropwhile(
-            lambda frame: frame[2] != request.function.__name__,
-            traceback.extract_stack()))
+        backtrace = list(
+            itertools.dropwhile(
+                lambda frame: frame[2] != request.function.__name__,
+                traceback.extract_stack(),
+            )
+        )
         return backtrace[1:-1]
 
     with teststack.push(testbox):
@@ -482,25 +524,29 @@ def test_box_pass_optimization(boxclass, teststack, request):
 
 def test_box_pass_optimization_complex(boxclass, teststack, request):
     testbox = boxclass()
-    testbox.put('a', 1)
-    testbox.put('b', 1)
-    testbox.put('c', 1)
-    testbox.put('d', 1)
+    testbox.put("a", 1)
+    testbox.put("b", 1)
+    testbox.put("c", 1)
+    testbox.put("d", 1)
 
     def passthrough(fn):
         def wrapper(*args, **kwargs):
             return fn(*args, **kwargs)
+
         return wrapper
 
-    @teststack.pass_('a')
-    @teststack.pass_('b')
+    @teststack.pass_("a")
+    @teststack.pass_("b")
     @passthrough
-    @teststack.pass_('c')
-    @teststack.pass_('d')
+    @teststack.pass_("c")
+    @teststack.pass_("d")
     def fn(a, b, c, d):
-        backtrace = list(itertools.dropwhile(
-            lambda frame: frame[2] != request.function.__name__,
-            traceback.extract_stack()))
+        backtrace = list(
+            itertools.dropwhile(
+                lambda frame: frame[2] != request.function.__name__,
+                traceback.extract_stack(),
+            )
+        )
         return backtrace[1:-1]
 
     with teststack.push(testbox):
@@ -512,60 +558,61 @@ def test_chainbox_put_changes_box(teststack):
     testchainbox = picobox.ChainBox(testbox)
 
     with teststack.push(testchainbox):
-        with pytest.raises(KeyError, match='the-key'):
-            teststack.get('the-key')
-        teststack.put('the-key', 42)
+        with pytest.raises(KeyError, match="the-key"):
+            teststack.get("the-key")
+        teststack.put("the-key", 42)
 
-        assert testbox.get('the-key') == 42
+        assert testbox.get("the-key") == 42
 
 
 def test_chainbox_get_chained(teststack):
     testbox_a = picobox.Box()
-    testbox_a.put('the-key', 42)
+    testbox_a.put("the-key", 42)
 
     testbox_b = picobox.Box()
-    testbox_b.put('the-key', 13)
-    testbox_b.put('the-pin', 12)
+    testbox_b.put("the-key", 13)
+    testbox_b.put("the-pin", 12)
 
     testchainbox = picobox.ChainBox(testbox_a, testbox_b)
 
     with teststack.push(testchainbox):
-        assert testchainbox.get('the-key') == 42
-        assert testchainbox.get('the-pin') == 12
+        assert testchainbox.get("the-key") == 42
+        assert testchainbox.get("the-pin") == 12
 
 
 def test_stack_isolated(boxclass):
     testbox_a = picobox.Box()
-    testbox_a.put('the-key', 42)
+    testbox_a.put("the-key", 42)
 
     testbox_b = picobox.Box()
-    testbox_b.put('the-pin', 12)
+    testbox_b.put("the-pin", 12)
 
     teststack_a = picobox.Stack()
     teststack_b = picobox.Stack()
 
     with teststack_a.push(testbox_a):
         with pytest.raises(RuntimeError) as excinfo:
-            teststack_b.get('the-key')
+            teststack_b.get("the-key")
         assert str(excinfo.value) == (
-            'No boxes found on the stack, please `.push()` a box first.')
+            "No boxes found on the stack, please `.push()` a box first."
+        )
 
         with teststack_b.push(testbox_b):
-            with pytest.raises(KeyError, match='the-pin'):
-                teststack_a.get('the-pin')
-            assert teststack_b.get('the-pin') == 12
+            with pytest.raises(KeyError, match="the-pin"):
+                teststack_a.get("the-pin")
+            assert teststack_b.get("the-pin") == 12
 
 
 def test_push_pop_as_regular_functions(teststack):
-    @teststack.pass_('magic')
+    @teststack.pass_("magic")
     def do(magic):
         return magic + 1
 
     foobox = picobox.Box()
-    foobox.put('magic', 42)
+    foobox.put("magic", 42)
 
     barbox = picobox.Box()
-    barbox.put('magic', 13)
+    barbox.put("magic", 13)
 
     teststack.push(foobox)
     assert do() == 43


### PR DESCRIPTION
While I'm generally not a huge fan of auto formatting, I cannot deny
that this is a good way to at least ensure that the code style is
homogeneous across the code base. Since Black became a standard
de-factor auto formatting tool in Python world, let's start using it.