### PR TITLE
Add type annotations to public interfaces

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,9 +29,10 @@ Features
 * Support scopes (e.g. singleton, threadlocal, contextvars).
 * Push boxes on stack, and use the top one to access values.
 * Thread-safe.
-* Lightweight (~450 LOC including scopes).
-* Zero dependencies (on python3).
+* Lightweight (~500 LOC including scopes).
+* Zero dependencies.
 * Pure Python.
+* Annotated with types.
 
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,7 @@ pygments_style = "sphinx"
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 autodoc_member_order = "bysource"
 autodoc_mock_imports = ["contextvars", "flask"]
+autodoc_typehints = "none"
 
 # -- HTML output
 html_use_index = False

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -344,6 +344,9 @@ Release Notes
 * Drop ``Python 3.4`` and ``Python 3.5`` support. Everyone is advised to move
   on to ``Python 3.6`` at least.
 
+* Add type annotations to public interface. Now users can use ``mypy`` to
+  leverage type checking in their code base.
+
 2.2.0
 `````
 

--- a/src/picobox/_box.py
+++ b/src/picobox/_box.py
@@ -3,6 +3,7 @@
 import functools
 import inspect
 import threading
+import typing as t
 
 from . import _scopes
 
@@ -19,7 +20,7 @@ class _missing:
 _missing = _missing()
 
 
-class Box(object):
+class Box:
     """Box is a dependency injection (DI) container.
 
     DI container is an object that contains any amount of factories, one for
@@ -51,7 +52,13 @@ class Box(object):
         self._scope_instances = {}
         self._lock = threading.RLock()
 
-    def put(self, key, value=_missing, factory=_missing, scope=_missing):
+    def put(
+        self,
+        key: t.Hashable,
+        value: t.Any = _missing,
+        factory: t.Callable[[], t.Any] = _missing,
+        scope: t.Type[_scopes.Scope] = _missing,
+    ) -> None:
         """Define a dependency (aka service) within the box instance.
 
         A dependency can be expressed either directly, by passing a concrete
@@ -109,7 +116,7 @@ class Box(object):
         with self._lock:
             self._store[key] = (scope, factory)
 
-    def get(self, key, default=_missing):
+    def get(self, key: t.Hashable, default: t.Any = _missing) -> t.Any:
         """Retrieve a dependency (aka service) out of the box instance.
 
         The process involves creation of requested dependency by calling an
@@ -149,7 +156,7 @@ class Box(object):
 
         return value
 
-    def pass_(self, key, as_=_missing):
+    def pass_(self, key: t.Hashable, as_: t.Text = _missing):
         r"""Pass a dependency to a function if nothing explicitly passed.
 
         The decorator implements late binding which means it does not require
@@ -228,14 +235,20 @@ class ChainBox(Box):
     .. versionadded:: 1.1
     """
 
-    def __init__(self, *boxes):
-        self._boxes = boxes or [Box()]
+    def __init__(self, *boxes: Box):
+        self._boxes = boxes or (Box(),)
 
-    def put(self, key, value=_missing, factory=_missing, scope=_missing):
+    def put(
+        self,
+        key: t.Hashable,
+        value: t.Any = _missing,
+        factory: t.Callable[[], t.Any] = _missing,
+        scope: t.Type[_scopes.Scope] = _missing,
+    ) -> None:
         """Same as :meth:`Box.put` but applies to first underlying box."""
         return self._boxes[0].put(key, value, factory, scope)
 
-    def get(self, key, default=_missing):
+    def get(self, key: t.Hashable, default: t.Any = _missing) -> t.Any:
         """Same as :meth:`Box.get` but looks up for key in underlying boxes."""
         for box in self._boxes:
             try:

--- a/src/picobox/_scopes.py
+++ b/src/picobox/_scopes.py
@@ -2,6 +2,7 @@
 
 import abc
 import threading
+import typing as t
 
 try:
     import contextvars as _contextvars
@@ -25,11 +26,11 @@ class Scope(metaclass=abc.ABCMeta):
     """
 
     @abc.abstractmethod
-    def set(self, key, value):
+    def set(self, key: t.Hashable, value: t.Any) -> None:
         """Bind `value` to `key` in current execution context."""
 
     @abc.abstractmethod
-    def get(self, key):
+    def get(self, key: t.Hashable) -> t.Any:
         """Get `value` by `key` for current execution context."""
 
 
@@ -39,10 +40,10 @@ class singleton(Scope):
     def __init__(self):
         self._store = {}
 
-    def set(self, key, value):
+    def set(self, key: t.Hashable, value: t.Any) -> None:
         self._store[key] = value
 
-    def get(self, key):
+    def get(self, key: t.Hashable) -> t.Any:
         return self._store[key]
 
 
@@ -52,14 +53,14 @@ class threadlocal(Scope):
     def __init__(self):
         self._local = threading.local()
 
-    def set(self, key, value):
+    def set(self, key: t.Hashable, value: t.Any) -> None:
         try:
             store = self._local.store
         except AttributeError:
             store = self._local.store = {}
         store[key] = value
 
-    def get(self, key):
+    def get(self, key: t.Hashable) -> t.Any:
         try:
             rv = self._local.store[key]
         except AttributeError:
@@ -82,14 +83,14 @@ class contextvars(Scope):
     def __init__(self):
         self._store = {}
 
-    def set(self, key, value):
+    def set(self, key: t.Hashable, value: t.Any) -> None:
         try:
             var = self._store[key]
         except KeyError:
             var = self._store[key] = _contextvars.ContextVar("picobox")
         var.set(value)
 
-    def get(self, key):
+    def get(self, key: t.Hashable) -> t.Any:
         try:
             return self._store[key].get()
         except LookupError:
@@ -99,10 +100,10 @@ class contextvars(Scope):
 class noscope(Scope):
     """Do not share instances, create them each time on demand."""
 
-    def set(self, key, value):
+    def set(self, key: t.Hashable, value: t.Any) -> None:
         pass
 
-    def get(self, key):
+    def get(self, key: t.Hashable) -> t.Any:
         raise KeyError(key)
 
 

--- a/src/picobox/_stack.py
+++ b/src/picobox/_stack.py
@@ -1,8 +1,9 @@
 """Picobox API to work with a box at the top of the stack."""
 
-import threading
-import functools
 import contextlib
+import functools
+import threading
+import typing as t
 
 from ._box import Box, ChainBox
 
@@ -48,7 +49,7 @@ def _create_push_context_manager(box, pop_callback):
         assert pop_callback() is box
 
 
-class Stack(object):
+class Stack:
     """Stack is a dependency injection (DI) container for containers (boxes).
 
     While :class:`Box` is a great way to manage dependencies, it has no means
@@ -92,7 +93,7 @@ class Stack(object):
     .. versionadded:: 2.2
     """
 
-    def __init__(self, name=None):
+    def __init__(self, name: t.Text = None):
         self._name = name
         self._stack = []
         self._lock = threading.Lock()
@@ -112,7 +113,7 @@ class Stack(object):
             name = "0x%x" % id(self)
         return "<Stack (%s)>" % name
 
-    def push(self, box, chain=False):
+    def push(self, box: Box, chain: bool = False):
         """Push a :class:`Box` instance to the top of the stack.
 
         Returns a context manager, that will automatically pop the box from the
@@ -135,7 +136,7 @@ class Stack(object):
             self._stack.append(box)
         return _create_push_context_manager(self._stack[-1], self._stack.pop)
 
-    def pop(self):
+    def pop(self) -> Box:
         """Pop the box from the top of the stack.
 
         Should be called once for every corresponding call to :meth:`.push` in


### PR DESCRIPTION
Despite not being a huge fan of type annotations in Python, it seems a
lot of projects are using them trying to reap some benefits. So this
patch adds type annotations to publicly exposed API.

Closes #46