### PR TITLE
Add Python 3.10 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "pypy-3.7"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy-3.8"]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -355,6 +355,8 @@ Release Notes
 
 (unreleased)
 
+* Add ``Python 3.10`` support.
+
 * Drop ``Python 2.7`` support. It's dead for more than a year anyway. Those who
   want to use picobox with ``Python 2`` should stick with ``2.x`` branch.
 
@@ -366,6 +368,7 @@ Release Notes
 
 * Make some parameters keyword-only: ``factory`` and ``scope`` in ``Box.put()``,
   ``as_`` in ``Box.pass_()`` and ``chain`` in ``picobox.push()``.
+
 
 2.2.0
 `````

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development :: Libraries",

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -3,6 +3,7 @@
 import collections
 import inspect
 import itertools
+import sys
 import traceback
 
 import picobox
@@ -402,7 +403,11 @@ def test_box_pass_unexpected_argument(boxclass):
     with pytest.raises(TypeError) as excinfo:
         fn(1, 2)
 
-    assert str(excinfo.value) == "fn() got an unexpected keyword argument 'd'"
+    expected = "fn() got an unexpected keyword argument 'd'"
+    if sys.version_info >= (3, 10):
+        expected = f"test_box_pass_unexpected_argument.<locals>.{expected}"
+
+    assert str(excinfo.value) == expected
 
 
 def test_box_pass_keyerror(boxclass):

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -1,6 +1,7 @@
 """Test picobox's stack interface."""
 
 import itertools
+import sys
 import traceback
 
 import picobox
@@ -472,7 +473,11 @@ def test_box_pass_unexpected_argument(boxclass, teststack):
         with pytest.raises(TypeError) as excinfo:
             fn(1, 2)
 
-    assert str(excinfo.value) == "fn() got an unexpected keyword argument 'd'"
+    expected = "fn() got an unexpected keyword argument 'd'"
+    if sys.version_info >= (3, 10):
+        expected = f"test_box_pass_unexpected_argument.<locals>.{expected}"
+
+    assert str(excinfo.value) == expected
 
 
 def test_box_pass_keyerror(boxclass, teststack):


### PR DESCRIPTION
There's nothing to be changed in picobox sources in order to support
CPython 3.10. This patch makes support official by fixing two tests and
adding the version to PyPI classifiers.