### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy-3.8"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.8"]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -360,8 +360,8 @@ Release Notes
 * Drop ``Python 2.7`` support. It's dead for more than a year anyway. Those who
   want to use picobox with ``Python 2`` should stick with ``2.x`` branch.
 
-* Drop ``Python 3.4`` and ``Python 3.5`` support. Everyone is advised to move
-  on to ``Python 3.6`` at least.
+* Drop ``Python 3.4``, ``Python 3.5`` and ``Python 3.6`` support. They reached
+  their end-of-life and are not maintained anymore.
 
 * Add type annotations to public interface. Now users can use ``mypy`` to
   leverage type checking in their code base.

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setuptools.setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
The 3.6 version reached its end-of-life and are not maintained anymore.
Please reach out to https://devguide.python.org/#branchstatus for
further details regarding maintained python branches.