### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy-3.8"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "pypy-3.8"]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -350,6 +350,13 @@ Release Notes
     backward incompatible changes will be released along with bumping major
     version component.
 
+3.1.0
+`````
+
+(unreleased)
+
+* Drop ``Python 3.7`` support. It reached its end-of-life recently.
+
 3.0.0
 `````
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "picobox"
 description = "Dependency injection framework designed with Python in mind."
 readme = "README.rst"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = "MIT"
 authors = [
   { name = "Ihor Kalnytskyi", email = "ihor@kalnytskyi.com" },
@@ -17,7 +17,6 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",

--- a/src/picobox/_scopes.py
+++ b/src/picobox/_scopes.py
@@ -75,7 +75,7 @@ class contextvars(Scope):
     in asynchronous applications to share dependencies between coroutines of
     the same :class:`asyncio.Task`.
 
-    .. __: https://docs.python.org/3.7/library/contextvars.html#asyncio-support
+    .. __: https://docs.python.org/3/library/contextvars.html#asyncio-support
 
     .. versionadded:: 2.1
     """


### PR DESCRIPTION
Python 3.7 just recently reached its end-of-life. Since it's no-brainer to upgrade to at least 3.8, I see no reason to encourage 3.7 adoption by supporting the unsupported version of Python. Let's bury it in the annals of history.