### PR TITLE
Add Python 3.12

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Prepare artifacts
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Run lints
         run: pipx run -- hatch run lint:run
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "pypy-3.8"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.8"]
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Run sphinx
         run: pipx run -- hatch run docs:run

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,11 +1,11 @@
 import os
-import pkg_resources
+import importlib.metadata
 
 
 # -- Project settings
 project = "Picobox"
 copyright = "2017, Ihor Kalnytskyi"
-release = pkg_resources.get_distribution("picobox").version
+release = importlib.metadata.version("picobox")
 version = ".".join(release.split(".")[:2])
 
 # -- General settings

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -355,6 +355,8 @@ Release Notes
 
 (unreleased)
 
+* Add ``Python 3.12`` support.
+
 * Drop ``Python 3.7`` support. It reached its end-of-life recently.
 
 3.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
   "Topic :: Software Development :: Libraries",


### PR DESCRIPTION
Python 3.12 is the latest stable version of CPython. Even though there's no special support is needed, it's always a good idea to official claim support by announcing version in the metadata and running tests on CI.