### PR TITLE
Use 'ruff format', instead of 'black'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,11 +42,8 @@ scripts.run = "python -m pytest --strict {args:-vv}"
 
 [tool.hatch.envs.lint]
 detached = true
-dependencies = [
-  "black >= 23.9.1",
-  "ruff == 0.0.292",
-]
-scripts.run = ["ruff {args:.}", "black --check --diff {args:.}"]
+dependencies = ["ruff == 0.1.6"]
+scripts.run = ["ruff check {args:.}", "ruff format --check --diff {args:.}"]
 
 [tool.hatch.envs.docs]
 dependencies = ["sphinx", "sphinx_rtd_theme"]
@@ -54,7 +51,7 @@ scripts.run = "sphinx-build -W -b html docs docs/_build/"
 
 [tool.ruff]
 select = ["F", "E", "W", "I", "S", "FBT", "B", "C4", "DTZ", "T10", "ISC", "RET", "SLF", "RUF"]
-ignore = ["S101", "B904"]
+ignore = ["S101", "B904", "ISC001"]
 
 [tool.ruff.isort]
 known-first-party = ["picobox"]


### PR DESCRIPTION
Despite being the de facto standard in the community, let's switch from the black formatter to the ruff formatter. The latter is mostly compatible with the former but dozen times faster (not relevant here) and is designed to be compatible with its linting rules. So why use many tools if I can use just one?

Since picobox is a pet project and is a great playground for me, let's see how far 'ruff format' can get.