### PR TITLE
Drop if-s arrount contextvars scope

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,7 +16,7 @@ exclude_patterns = ["_build", "_themes"]
 pygments_style = "sphinx"
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 autodoc_member_order = "bysource"
-autodoc_mock_imports = ["contextvars", "flask"]
+autodoc_mock_imports = ["flask"]
 autodoc_typehints = "none"
 
 # -- HTML output

--- a/src/picobox/__init__.py
+++ b/src/picobox/__init__.py
@@ -1,14 +1,8 @@
 """Dependency injection framework designed with Python in mind."""
 
 from ._box import Box, ChainBox
-from ._scopes import Scope, noscope, singleton, threadlocal
+from ._scopes import Scope, contextvars, noscope, singleton, threadlocal
 from ._stack import Stack, get, pass_, pop, push, put
-
-try:
-    from ._scopes import contextvars
-except ImportError:
-    pass
-
 
 __all__ = [
     "Box",

--- a/src/picobox/_scopes.py
+++ b/src/picobox/_scopes.py
@@ -1,13 +1,9 @@
 """Scope interface and builtin implementations."""
 
 import abc
+import contextvars as _contextvars
 import threading
 import typing as t
-
-try:
-    import contextvars as _contextvars
-except ImportError:
-    _contextvars = None
 
 
 class Scope(metaclass=abc.ABCMeta):
@@ -105,7 +101,3 @@ class noscope(Scope):
 
     def get(self, key: t.Hashable) -> t.Any:
         raise KeyError(key)
-
-
-if not _contextvars:
-    del contextvars

--- a/tests/test_scopes.py
+++ b/tests/test_scopes.py
@@ -1,5 +1,6 @@
 """Test picobox's scopes implementations."""
 
+import contextvars as _contextvars
 import threading
 
 import pytest
@@ -19,7 +20,6 @@ def threadlocal():
 
 @pytest.fixture(scope="function")
 def contextvars():
-    pytest.importorskip("contextvars")
     return picobox.contextvars()
 
 
@@ -78,24 +78,10 @@ def exec_context():
     """Run a given callback in a separate context (PEP 567)."""
 
     def executor(callback, *args, **kwargs):
-        import contextvars
-
-        context = contextvars.copy_context()
+        context = _contextvars.copy_context()
         return context.run(callback, *args, **kwargs)
 
-    pytest.importorskip("contextvars")
     return executor
-
-
-def test_scope_contextvars_attribute_error(monkeypatch):
-    try:
-        __import__("contextvars")
-        pytest.skip("could import 'contextvars'")
-    except ImportError:
-        pass
-
-    with pytest.raises(AttributeError, match="has no attribute 'contextvars'"):
-        _ = picobox.contextvars
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The contextvars module has been a part of the Python standard library since Python 3.7. There's no need to remain backward compatible with older versions anymore.