### PR TITLE
Revive Read-the-Docs publishing

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3"
+
+python:
+  install:
+    - requirements: docs/requirements.txt
+    - method: pip
+      path: .
+
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: true

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-import os
 import importlib.metadata
 
 
@@ -23,12 +22,7 @@ autodoc_typehints = "none"
 html_use_index = False
 html_show_sourcelink = False
 html_logo = "_static/picobox.svg"
-
-if not os.environ.get("READTHEDOCS") == "True":
-    import sphinx_rtd_theme
-
-    html_theme = "sphinx_rtd_theme"
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+html_theme = "sphinx_rtd_theme"
 
 # Sphinx does not support "code" directive preserving default (docutils)
 # behaviour. This means code won't be highlighted which is not good. In

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+sphinx_rtd_theme

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = ["ruff == 0.1.6"]
 scripts.run = ["ruff check {args:.}", "ruff format --check --diff {args:.}"]
 
 [tool.hatch.envs.docs]
-dependencies = ["sphinx", "sphinx_rtd_theme"]
+pre-install-commands = ["python -m pip install -r docs/requirements.txt"]
 scripts.run = "sphinx-build -W -b html docs docs/_build/"
 
 [tool.ruff]


### PR DESCRIPTION
Apparently, the picobox documentation wasn't published for the 3.0 release because the Read-the-Docs platform started to require its own configuration file [1], `.readthedocs.yaml`, for publishing to work.

[1]: https://blog.readthedocs.com/migrate-configuration-v2/