### PR TITLE
Throw RuntimeError from .pop() when stack is empty

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -367,6 +367,11 @@ Release Notes
   lost its coroutine function marker, i.e. ``inspect.iscoroutinefunction()``
   returned ``False``.
 
+* Fix a bug when ``picobox.pop()`` threw a generic ``IndexError`` when there
+  were no pushed boxes on stack. Now ``RuntimeError`` exception is thrown
+  instead with a good-looking error message. The behavior is now consistent
+  with other functions such as ``picobox.put()`` or ``picobox.get()``.
+
 4.0.0
 `````
 

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -733,8 +733,8 @@ def test_stack_push_pop_function_interface(boxclass, teststack):
     assert teststack.pop() is foobox
 
 
-def test_stack_pop_indexerror(teststack):
-    with pytest.raises(IndexError) as excinfo:
+def test_stack_pop_runtimeerror(teststack):
+    with pytest.raises(RuntimeError) as excinfo:
         teststack.pop()
 
-    assert str(excinfo.value) == "pop from empty list"
+    assert str(excinfo.value) == "No boxes found on the stack, please `.push()` a box first."


### PR DESCRIPTION
The `picobox.pop()` function used to throw `IndexError` when invoked with an empty stack. This was never an intentional move, and just happened because we weren't careful enough.

This patch makes the `.pop()` function to throw `RuntimeError` instead with a good-looking error message saying that there's no boxes on stack, similar to what `picobox.put()` or `picobox.get()` are doing.

This patch doesn't introduce a major bump in the version despite being a backward incompatible change. Invoking `.pop()` when stack is empty is a symptom of a poorly designed application, and should not be happening in the first place.