### PR TITLE
Turn MyPy's no-untyped-def/no-untyped-call on

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = ["ruff == 0.4.*"]
 scripts.run = ["ruff check {args:.}", "ruff format --check --diff {args:.}"]
 
 [tool.hatch.envs.type]
-dependencies = ["mypy", "flask"]
+dependencies = ["mypy", "typing-extensions", "flask"]
 scripts.run = ["mypy {args}"]
 
 [tool.hatch.envs.docs]
@@ -97,6 +97,4 @@ strict = true
 disable_error_code = [
   "attr-defined",
   "comparison-overlap",
-  "no-untyped-call",
-  "no-untyped-def",
 ]

--- a/src/picobox/_scopes.py
+++ b/src/picobox/_scopes.py
@@ -33,8 +33,8 @@ class Scope(metaclass=abc.ABCMeta):
 class singleton(Scope):
     """Share instances across application."""
 
-    def __init__(self):
-        self._store = {}
+    def __init__(self) -> None:
+        self._store: t.Dict[t.Hashable, t.Any] = {}
 
     def set(self, key: t.Hashable, value: t.Any) -> None:
         self._store[key] = value
@@ -46,7 +46,7 @@ class singleton(Scope):
 class threadlocal(Scope):
     """Share instances across the same thread."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._local = threading.local()
 
     def set(self, key: t.Hashable, value: t.Any) -> None:
@@ -76,8 +76,8 @@ class contextvars(Scope):
     .. versionadded:: 2.1
     """
 
-    def __init__(self):
-        self._store = {}
+    def __init__(self) -> None:
+        self._store: t.Dict[t.Hashable, _contextvars.ContextVar[t.Any]] = {}
 
     def set(self, key: t.Hashable, value: t.Any) -> None:
         try:

--- a/src/picobox/ext/flaskscopes.py
+++ b/src/picobox/ext/flaskscopes.py
@@ -1,5 +1,6 @@
 """Scopes for Flask framework."""
 
+import typing as t
 import uuid
 
 import flask
@@ -10,9 +11,8 @@ import picobox
 class _flaskscope(picobox.Scope):
     """A base class for Flask scopes."""
 
-    _store = None
-
-    def __init__(self):
+    def __init__(self, store: object) -> None:
+        self._store = store
         # Both application and request scopes are merely proxies to
         # corresponding storage objects in Flask. This means multiple
         # scope instances will share the same storage object under the
@@ -21,7 +21,7 @@ class _flaskscope(picobox.Scope):
         # distinguish dependencies stored by different scope instances.
         self._uuid = str(uuid.uuid4())
 
-    def set(self, key, value):
+    def set(self, key: t.Hashable, value: t.Any) -> None:
         try:
             dependencies = self._store.__dependencies__
         except AttributeError:
@@ -34,7 +34,7 @@ class _flaskscope(picobox.Scope):
 
         dependencies[key] = value
 
-    def get(self, key):
+    def get(self, key: t.Hashable) -> t.Any:
         try:
             rv = self._store.__dependencies__[self._uuid][key]
         except (AttributeError, KeyError):
@@ -60,9 +60,8 @@ class application(_flaskscope):
     .. versionadded:: 2.2
     """
 
-    @property
-    def _store(self):
-        return flask.current_app
+    def __init__(self) -> None:
+        super().__init__(flask.current_app)
 
 
 class request(_flaskscope):
@@ -78,6 +77,5 @@ class request(_flaskscope):
     .. versionadded:: 2.2
     """
 
-    @property
-    def _store(self):
-        return flask.g
+    def __init__(self) -> None:
+        super().__init__(flask.g)


### PR DESCRIPTION
The 'no-untyped-def' and 'no-untyped-call' error codes have been disabled before due to the source code not being ready for them. This patch delivers amends to the code base, and enables these rules.