### PR TITLE
Turn mypy:no-any-return on

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,6 @@ disable_error_code = [
   "comparison-overlap",
   "import-not-found",
   "misc",
-  "no-any-return",
   "no-untyped-call",
   "no-untyped-def",
   "type-arg",

--- a/src/picobox/_stack.py
+++ b/src/picobox/_stack.py
@@ -96,8 +96,8 @@ class Stack:
     """
 
     def __init__(self, name: t.Optional[str] = None):
-        self._name = name
-        self._stack = []
+        self._name = name or "0x%x" % id(self)
+        self._stack: list[Box] = []
         self._lock = threading.Lock()
 
         # A proxy object that proxies all calls to a box instance on the top
@@ -108,10 +108,7 @@ class Stack:
         self._topbox = _create_stack_proxy(self._stack)
 
     def __repr__(self):
-        name = self._name
-        if not self._name:
-            name = "0x%x" % id(self)
-        return "<Stack (%s)>" % name
+        return f"<Stack ({self._name})>"
 
     def push(self, box: Box, *, chain: bool = False) -> t.ContextManager[Box]:
         """Push a :class:`Box` instance to the top of the stack.

--- a/src/picobox/ext/asgiscopes.py
+++ b/src/picobox/ext/asgiscopes.py
@@ -6,8 +6,12 @@ import weakref
 
 import picobox
 
-_current_app_store = contextvars.ContextVar(f"{__name__}.current-app-store")
-_current_req_store = contextvars.ContextVar(f"{__name__}.current-req-store")
+if t.TYPE_CHECKING:
+    Store = contextvars.ContextVar[weakref.WeakKeyDictionary]
+
+
+_current_app_store: "Store" = contextvars.ContextVar(f"{__name__}.current-app-store")
+_current_req_store: "Store" = contextvars.ContextVar(f"{__name__}.current-req-store")
 
 
 class ScopeMiddleware:
@@ -52,7 +56,7 @@ class ScopeMiddleware:
 class _asgiscope(picobox.Scope):
     """A base class for ASGI scopes."""
 
-    _store_cvar: contextvars.ContextVar
+    _store_cvar: "Store"
 
     @property
     def _store(self) -> t.MutableMapping[t.Hashable, t.Any]:

--- a/src/picobox/ext/wsgiscopes.py
+++ b/src/picobox/ext/wsgiscopes.py
@@ -9,9 +9,11 @@ import picobox
 if t.TYPE_CHECKING:
     from _typeshed.wsgi import StartResponse, WSGIApplication, WSGIEnvironment
 
+    Store = contextvars.ContextVar[weakref.WeakKeyDictionary]
 
-_current_app_store = contextvars.ContextVar(f"{__name__}.current-app-store")
-_current_req_store = contextvars.ContextVar(f"{__name__}.current-req-store")
+
+_current_app_store: "Store" = contextvars.ContextVar(f"{__name__}.current-app-store")
+_current_req_store: "Store" = contextvars.ContextVar(f"{__name__}.current-req-store")
 
 
 class ScopeMiddleware:
@@ -61,7 +63,7 @@ class ScopeMiddleware:
 class _wsgiscope(picobox.Scope):
     """A base class for WSGI scopes."""
 
-    _store_cvar: contextvars.ContextVar
+    _store_cvar: "Store"
 
     @property
     def _store(self) -> t.MutableMapping[t.Hashable, t.Any]:


### PR DESCRIPTION
The 'no-any-return' error code has been disabled before due to the code not being ready for it. This patch delivers amends to the code base, and enables the rule that must be enabled.