### PR TITLE
Turn mypy:assignment/misc/import-not-found on

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,6 +23,7 @@ intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 autodoc_member_order = "bysource"
 autodoc_mock_imports = ["flask"]
 autodoc_typehints = "description"
+autodoc_preserve_defaults = True
 
 # -- HTML output
 html_use_index = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = ["ruff == 0.2.*"]
 scripts.run = ["ruff check {args:.}", "ruff format --check --diff {args:.}"]
 
 [tool.hatch.envs.type]
-dependencies = ["mypy"]
+dependencies = ["mypy", "flask"]
 scripts.run = ["mypy {args}"]
 
 [tool.hatch.envs.docs]
@@ -95,11 +95,8 @@ files = ["src"]
 pretty = true
 strict = true
 disable_error_code = [
-  "assignment",
   "attr-defined",
   "comparison-overlap",
-  "import-not-found",
-  "misc",
   "no-untyped-call",
   "no-untyped-def",
 ]

--- a/src/picobox/_stack.py
+++ b/src/picobox/_stack.py
@@ -97,7 +97,7 @@ class Stack:
 
     def __init__(self, name: t.Optional[str] = None):
         self._name = name or "0x%x" % id(self)
-        self._stack: list[Box] = []
+        self._stack: t.List[Box] = []
         self._lock = threading.Lock()
 
         # A proxy object that proxies all calls to a box instance on the top


### PR DESCRIPTION
Both 'assignment' and 'misc' and 'import-not-found' error codes has been disabled before due to the code not being ready for it. This patch delivers amends to the code base, and enables the rule that must be enabled.