### PR TITLE
Use proper CPython version in CI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,11 +12,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.12"
-
       - name: Prepare artifacts
         run: |
           pipx run -- hatch build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: "3.12"
 
       - name: Run lints
-        run: pipx run -- hatch run lint:run
+        run: python3 -m pip install hatch && hatch run lint:run
 
   test:
     strategy:
@@ -38,7 +38,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Run pytest
-        run: pipx run -- hatch run test:run
+        run: python3 -m pip install hatch && hatch run test:run
 
   type:
     runs-on: ubuntu-latest
@@ -52,7 +52,7 @@ jobs:
           python-version: "3.12"
 
       - name: Run lints
-        run: pipx run -- hatch run type:run
+        run: python3 -m pip install hatch && hatch run type:run
 
   docs:
     runs-on: ubuntu-latest
@@ -66,4 +66,4 @@ jobs:
           python-version: "3.12"
 
       - name: Run sphinx
-        run: pipx run -- hatch run docs:run
+        run: python3 -m pip install hatch && hatch run docs:run


### PR DESCRIPTION
Apparently CI has been completely broken I don't know how long due to pipx using the python interpreter it was installed for, instead of using the one we specifically prepared for tests. This patch uses python3 alias to install hatch and run tests, which must guarantee proper python interpreter.