### PR TITLE
Turn MyPy's attr-defined/comparison-overlap errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,3 @@ python_version = "3.8"
 files = ["src"]
 pretty = true
 strict = true
-disable_error_code = [
-  "attr-defined",
-  "comparison-overlap",
-]

--- a/src/picobox/_box.py
+++ b/src/picobox/_box.py
@@ -197,7 +197,7 @@ class Box:
                 signature = inspect.signature(fn)
                 arguments = signature.bind_partial(*args, **kwargs)
 
-                for key, as_ in wrapper.__dependencies__:
+                for key, as_ in wrapper.__dependencies__:  # type: ignore[attr-defined]
                     if as_ is None:
                         as_ = key
 
@@ -217,7 +217,7 @@ class Box:
             else:
                 wrapper = fn_with_dependencies  # type: ignore[assignment]
 
-            wrapper.__dependencies__ = [(key, as_)]
+            wrapper.__dependencies__ = [(key, as_)]  # type: ignore[attr-defined]
             return wrapper
 
         return decorator


### PR DESCRIPTION
Finally remove latest error codes from MyPy dsiable list. Even though it requires few inline exceptions, I'll figure something out later.