### PR TITLE
Refactor picobox.contextvars

### DIFF
--- a/src/picobox/ext/asgiscopes.py
+++ b/src/picobox/ext/asgiscopes.py
@@ -7,7 +7,7 @@ import weakref
 import picobox
 
 if t.TYPE_CHECKING:
-    Store = weakref.WeakKeyDictionary[picobox.Scope, t.MutableMapping[t.Hashable, t.Any]]
+    Store = weakref.WeakKeyDictionary[picobox.Scope, t.Dict[t.Hashable, t.Any]]
     StoreCtxVar = contextvars.ContextVar[Store]
     ASGIScope = t.MutableMapping[str, t.Any]
     ASGIMessage = t.MutableMapping[str, t.Any]
@@ -65,7 +65,7 @@ class _asgiscope(picobox.Scope):
     _store_cvar: "StoreCtxVar"
 
     @property
-    def _store(self) -> t.MutableMapping[t.Hashable, t.Any]:
+    def _store(self) -> t.Dict[t.Hashable, t.Any]:
         try:
             store = self._store_cvar.get()
         except LookupError:

--- a/src/picobox/ext/wsgiscopes.py
+++ b/src/picobox/ext/wsgiscopes.py
@@ -9,7 +9,7 @@ import picobox
 if t.TYPE_CHECKING:
     from _typeshed.wsgi import StartResponse, WSGIApplication, WSGIEnvironment
 
-    Store = weakref.WeakKeyDictionary[picobox.Scope, t.MutableMapping[t.Hashable, t.Any]]
+    Store = weakref.WeakKeyDictionary[picobox.Scope, t.Dict[t.Hashable, t.Any]]
     StoreCtxVar = contextvars.ContextVar[Store]
 
 
@@ -67,7 +67,7 @@ class _wsgiscope(picobox.Scope):
     _store_cvar: "StoreCtxVar"
 
     @property
-    def _store(self) -> t.MutableMapping[t.Hashable, t.Any]:
+    def _store(self) -> t.Dict[t.Hashable, t.Any]:
         try:
             store = self._store_cvar.get()
         except LookupError:


### PR DESCRIPTION
There are two main reasons of this refactoring:

* Switch internal storage from dictionary to WeakKeyDectionary in order to make sure that dependencies got garbage collected once the scope instance is got removed.

* Add an internal _store property that returns the per-scope store instance to ease set()/get() implementations.