### PR TITLE
Embrace Ruff linter, use ALL rules

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,7 +5,7 @@ import importlib.metadata
 # -- Project settings
 project = "Picobox"
 author = "Ihor Kalnytskyi"
-copyright = "2017, Ihor Kalnytskyi"
+project_copyright = "2017, Ihor Kalnytskyi"
 release = importlib.metadata.version("picobox")
 version = ".".join(release.split(".")[:2])
 

--- a/examples/flask/wsgi.py
+++ b/examples/flask/wsgi.py
@@ -19,4 +19,4 @@ box.put("magic", 12)
 # to test the app since any attempt to override dependencies in tests
 # will fail due to later attempt to push a new box by request hooks.
 picobox.push(box)
-from example import app  # noqa
+from example import app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ scripts.run = "python -m pytest --strict-markers {args:-vv}"
 
 [tool.hatch.envs.lint]
 detached = true
-dependencies = ["ruff == 0.4.*"]
+dependencies = ["ruff == 0.5.*"]
 scripts.run = ["ruff check {args:.}", "ruff format --check --diff {args:.}"]
 
 [tool.hatch.envs.type]
@@ -55,39 +55,17 @@ scripts.run = "sphinx-build -W -b html docs docs/_build/"
 line-length = 100
 
 [tool.ruff.lint]
-select = [
-  "F",
-  "E",
-  "W",
-  "I",
-  "D",
-  "UP",
-  "S",
-  "FBT",
-  "B",
-  "C4",
-  "DTZ",
-  "T10",
-  "ISC",
-  "PIE",
-  "T20",
-  "PYI",
-  "PT",
-  "RET",
-  "SLF",
-  "SIM",
-  "TCH",
-  "ERA",
-  "RUF",
-]
-ignore = ["D107", "D203", "D213", "D401", "S101", "B904", "ISC001", "PT011", "SIM117"]
+select = ["ALL"]
+ignore = ["ANN", "PLR", "D107", "D203", "D213", "D401", "SIM117", "N801", "PLW2901", "PERF203", "COM812", "ISC001"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["picobox"]
 
 [tool.ruff.lint.per-file-ignores]
-"examples/*" = ["I", "D", "T20"]
-"tests/*" = ["D"]
+"docs/*" = ["INP001"]
+"examples/*" = ["I", "D", "T20", "INP001"]
+"examples/flask/wsgi.py" = ["F401", "E402"]
+"tests/*" = ["D", "S101", "ARG001", "BLE001", "INP001"]
 
 [tool.mypy]
 python_version = "3.8"

--- a/src/picobox/_scopes.py
+++ b/src/picobox/_scopes.py
@@ -1,5 +1,7 @@
 """Scope interface and builtin implementations."""
 
+from __future__ import annotations
+
 import abc
 import contextvars as _contextvars
 import threading
@@ -35,7 +37,7 @@ class singleton(Scope):
     """Share instances across application."""
 
     def __init__(self) -> None:
-        self._store: t.Dict[t.Hashable, t.Any] = {}
+        self._store: dict[t.Hashable, t.Any] = {}
 
     def set(self, key: t.Hashable, value: t.Any) -> None:
         self._store[key] = value
@@ -61,7 +63,7 @@ class threadlocal(Scope):
         try:
             rv = self._local.store[key]
         except AttributeError:
-            raise KeyError(key)
+            raise KeyError(key) from None
         return rv
 
 
@@ -77,13 +79,11 @@ class contextvars(Scope):
     .. versionadded:: 2.1
     """
 
-    _store_obj: (
-        "weakref.WeakKeyDictionary[Scope, t.Dict[t.Hashable, _contextvars.ContextVar[t.Any]]]"
-    )
+    _store_obj: weakref.WeakKeyDictionary[Scope, dict[t.Hashable, _contextvars.ContextVar[t.Any]]]
     _store_obj = weakref.WeakKeyDictionary()
 
     @property
-    def _store(self) -> t.Dict[t.Hashable, _contextvars.ContextVar[t.Any]]:
+    def _store(self) -> dict[t.Hashable, _contextvars.ContextVar[t.Any]]:
         try:
             scope_store = self._store_obj[self]
         except KeyError:
@@ -98,7 +98,7 @@ class contextvars(Scope):
         try:
             return self._store[key].get()
         except LookupError:
-            raise KeyError(key)
+            raise KeyError(key) from None
 
 
 class noscope(Scope):

--- a/src/picobox/ext/flaskscopes.py
+++ b/src/picobox/ext/flaskscopes.py
@@ -1,5 +1,7 @@
 """Scopes for Flask framework."""
 
+from __future__ import annotations
+
 import typing as t
 import weakref
 
@@ -10,7 +12,7 @@ import picobox
 if t.TYPE_CHECKING:
 
     class _flask_store_obj(t.Protocol):
-        __dependencies__: weakref.WeakKeyDictionary[picobox.Scope, t.Dict[t.Hashable, t.Any]]
+        __dependencies__: weakref.WeakKeyDictionary[picobox.Scope, dict[t.Hashable, t.Any]]
 
 
 class _flaskscope(picobox.Scope):
@@ -20,7 +22,7 @@ class _flaskscope(picobox.Scope):
         self._store_obj = t.cast("_flask_store_obj", store_obj)
 
     @property
-    def _store(self) -> t.Dict[t.Hashable, t.Any]:
+    def _store(self) -> dict[t.Hashable, t.Any]:
         try:
             store = self._store_obj.__dependencies__
         except AttributeError:

--- a/tests/ext/test_asgiscopes.py
+++ b/tests/ext/test_asgiscopes.py
@@ -242,7 +242,7 @@ def test_scope_value_shared(app_factory, client_factory, scope_factory):
         app_factory(
             ("/1", endpoint1),
             ("/2", endpoint2),
-        )
+        ),
     )
     client.run_endpoint("/1")
     client.run_endpoint("/2")
@@ -270,7 +270,7 @@ def test_scope_value_not_shared(app_factory, client_factory, scope_factory):
         app_factory(
             ("/1", endpoint1),
             ("/2", endpoint2),
-        )
+        ),
     )
     client.run_endpoint("/1")
     client.run_endpoint("/2")
@@ -407,7 +407,7 @@ async def test_scope_request_is_request_bound(app_factory, asyncclient_factory):
         app_factory(
             ("/1", endpoint1),
             ("/2", endpoint2),
-        )
+        ),
     )
 
     await asyncio.gather(

--- a/tests/ext/test_wsgiscopes.py
+++ b/tests/ext/test_wsgiscopes.py
@@ -207,7 +207,7 @@ def test_scope_value_shared(app_factory, client_factory, scope_factory):
         app_factory(
             ("/1", endpoint1),
             ("/2", endpoint2),
-        )
+        ),
     )
     client.run_endpoint("/1")
     client.run_endpoint("/2")
@@ -235,7 +235,7 @@ def test_scope_value_not_shared(app_factory, client_factory, scope_factory):
         app_factory(
             ("/1", endpoint1),
             ("/2", endpoint2),
-        )
+        ),
     )
     client.run_endpoint("/1")
     client.run_endpoint("/2")
@@ -389,7 +389,7 @@ def test_scope_request_is_request_bound(app_factory, client_factory):
         app_factory(
             ("/1", endpoint1),
             ("/2", endpoint2),
-        )
+        ),
     )
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -66,7 +66,7 @@ def test_box_put_factory_custom_scope(boxclass):
         [
             testbox.get("the-key"),
             testbox.get("the-key"),
-        ]
+        ],
     )
 
     namespace = "two"
@@ -74,7 +74,7 @@ def test_box_put_factory_custom_scope(boxclass):
         [
             testbox.get("the-key"),
             testbox.get("the-key"),
-        ]
+        ],
     )
 
     assert len(objects) == 4
@@ -471,7 +471,7 @@ def test_box_pass_optimization(request, boxclass):
             itertools.dropwhile(
                 lambda frame: frame[2] != request.function.__name__,
                 traceback.extract_stack(),
-            )
+            ),
         )
         return backtrace[1:-1]
 
@@ -501,7 +501,7 @@ def test_box_pass_optimization_complex(request, boxclass):
             itertools.dropwhile(
                 lambda frame: frame[2] != request.function.__name__,
                 traceback.extract_stack(),
-            )
+            ),
         )
         return backtrace[1:-1]
 
@@ -523,7 +523,7 @@ async def test_box_pass_optimization_async(request, boxclass):
             itertools.dropwhile(
                 lambda frame: frame[2] != request.function.__name__,
                 traceback.extract_stack(),
-            )
+            ),
         )
         return backtrace[1:-1]
 

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -79,7 +79,7 @@ def test_stack_put_factory_custom_scope(boxclass, teststack):
             [
                 teststack.get("the-key"),
                 teststack.get("the-key"),
-            ]
+            ],
         )
 
         namespace = "two"
@@ -87,7 +87,7 @@ def test_stack_put_factory_custom_scope(boxclass, teststack):
             [
                 teststack.get("the-key"),
                 teststack.get("the-key"),
-            ]
+            ],
         )
 
         assert len(objects) == 4
@@ -588,7 +588,7 @@ def test_stack_pass_optimization(request, boxclass, teststack):
             itertools.dropwhile(
                 lambda frame: frame[2] != request.function.__name__,
                 traceback.extract_stack(),
-            )
+            ),
         )
         return backtrace[1:-1]
 
@@ -619,7 +619,7 @@ def test_stack_pass_optimization_complex(request, boxclass, teststack):
             itertools.dropwhile(
                 lambda frame: frame[2] != request.function.__name__,
                 traceback.extract_stack(),
-            )
+            ),
         )
         return backtrace[1:-1]
 
@@ -642,7 +642,7 @@ async def test_stack_pass_optimization_async(request, boxclass, teststack):
             itertools.dropwhile(
                 lambda frame: frame[2] != request.function.__name__,
                 traceback.extract_stack(),
-            )
+            ),
         )
         return backtrace[1:-1]
 


### PR DESCRIPTION
Ruff comes with many handy rules out of box. Even though some of them are weird, some of them not applicable to this project, we better maintain the ignore list rather than select list. It looks like most of them are good enough to try.