### PR TITLE
Drop 'typing_extensions', use modern annotations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = ["ruff == 0.5.*"]
 scripts.run = ["ruff check {args:.}", "ruff format --check --diff {args:.}"]
 
 [tool.hatch.envs.type]
-dependencies = ["mypy", "typing-extensions", "flask"]
+dependencies = ["mypy", "flask"]
 scripts.run = ["mypy {args}"]
 
 [tool.hatch.envs.docs]
@@ -68,7 +68,6 @@ known-first-party = ["picobox"]
 "tests/*" = ["D", "S101", "ARG001", "BLE001", "INP001"]
 
 [tool.mypy]
-python_version = "3.8"
 files = ["src"]
 pretty = true
 strict = true

--- a/src/picobox/ext/asgiscopes.py
+++ b/src/picobox/ext/asgiscopes.py
@@ -3,19 +3,22 @@
 from __future__ import annotations
 
 import contextvars
-import typing as t
+import typing
 import weakref
 
 import picobox
 
-if t.TYPE_CHECKING:
-    Store = weakref.WeakKeyDictionary[picobox.Scope, t.Dict[t.Hashable, t.Any]]
+if typing.TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable, Hashable, MutableMapping
+    from typing import Any
+
+    Store = weakref.WeakKeyDictionary[picobox.Scope, dict[Hashable, Any]]
     StoreCtxVar = contextvars.ContextVar[Store]
-    ASGIScope = t.MutableMapping[str, t.Any]
-    ASGIMessage = t.MutableMapping[str, t.Any]
-    ASGIReceive = t.Callable[[], t.Awaitable[ASGIMessage]]
-    ASGISend = t.Callable[[ASGIMessage], t.Awaitable[None]]
-    ASGIApplication = t.Callable[[ASGIScope, ASGIReceive, ASGISend], t.Awaitable[None]]
+    ASGIScope = MutableMapping[str, Any]
+    ASGIMessage = MutableMapping[str, Any]
+    ASGIReceive = Callable[[], Awaitable[ASGIMessage]]
+    ASGISend = Callable[[ASGIMessage], Awaitable[None]]
+    ASGIApplication = Callable[[ASGIScope, ASGIReceive, ASGISend], Awaitable[None]]
 
 
 _current_app_store: StoreCtxVar = contextvars.ContextVar(f"{__name__}.current-app-store")
@@ -67,7 +70,7 @@ class _asgiscope(picobox.Scope):
     _store_cvar: StoreCtxVar
 
     @property
-    def _store(self) -> dict[t.Hashable, t.Any]:
+    def _store(self) -> dict[Hashable, Any]:
         try:
             store = self._store_cvar.get()
         except LookupError:
@@ -86,10 +89,10 @@ class _asgiscope(picobox.Scope):
             scope_store = store.setdefault(self, {})
         return scope_store
 
-    def set(self, key: t.Hashable, value: t.Any) -> None:
+    def set(self, key: Hashable, value: Any) -> None:
         self._store[key] = value
 
-    def get(self, key: t.Hashable) -> t.Any:
+    def get(self, key: Hashable) -> Any:
         return self._store[key]
 
 

--- a/src/picobox/ext/flaskscopes.py
+++ b/src/picobox/ext/flaskscopes.py
@@ -2,27 +2,29 @@
 
 from __future__ import annotations
 
-import typing as t
+import typing
 import weakref
 
 import flask
 
 import picobox
 
-if t.TYPE_CHECKING:
+if typing.TYPE_CHECKING:
+    from collections.abc import Hashable
+    from typing import Any
 
-    class _flask_store_obj(t.Protocol):
-        __dependencies__: weakref.WeakKeyDictionary[picobox.Scope, dict[t.Hashable, t.Any]]
+    class _flask_store_obj(typing.Protocol):
+        __dependencies__: weakref.WeakKeyDictionary[picobox.Scope, dict[Hashable, Any]]
 
 
 class _flaskscope(picobox.Scope):
     """A base class for Flask scopes."""
 
     def __init__(self, store_obj: object) -> None:
-        self._store_obj = t.cast("_flask_store_obj", store_obj)
+        self._store_obj = typing.cast("_flask_store_obj", store_obj)
 
     @property
-    def _store(self) -> dict[t.Hashable, t.Any]:
+    def _store(self) -> dict[Hashable, Any]:
         try:
             store = self._store_obj.__dependencies__
         except AttributeError:
@@ -34,10 +36,10 @@ class _flaskscope(picobox.Scope):
             scope_store = store.setdefault(self, {})
         return scope_store
 
-    def set(self, key: t.Hashable, value: t.Any) -> None:
+    def set(self, key: Hashable, value: Any) -> None:
         self._store[key] = value
 
-    def get(self, key: t.Hashable) -> t.Any:
+    def get(self, key: Hashable) -> Any:
         return self._store[key]
 
 

--- a/src/picobox/ext/wsgiscopes.py
+++ b/src/picobox/ext/wsgiscopes.py
@@ -3,15 +3,18 @@
 from __future__ import annotations
 
 import contextvars
-import typing as t
+import typing
 import weakref
 
 import picobox
 
-if t.TYPE_CHECKING:
+if typing.TYPE_CHECKING:
+    from collections.abc import Hashable, Iterable
+    from typing import Any
+
     from _typeshed.wsgi import StartResponse, WSGIApplication, WSGIEnvironment
 
-    Store = weakref.WeakKeyDictionary[picobox.Scope, t.Dict[t.Hashable, t.Any]]
+    Store = weakref.WeakKeyDictionary[picobox.Scope, dict[Hashable, Any]]
     StoreCtxVar = contextvars.ContextVar[Store]
 
 
@@ -45,7 +48,7 @@ class ScopeMiddleware:
         self,
         environ: WSGIEnvironment,
         start_response: StartResponse,
-    ) -> t.Iterable[bytes]:
+    ) -> Iterable[bytes]:
         """Define scopes and invoke the WSGI application."""
         # Storing the WSGI application's scope state within a ScopeMiddleware
         # instance because it's assumed that each WSGI middleware is typically
@@ -69,7 +72,7 @@ class _wsgiscope(picobox.Scope):
     _store_cvar: StoreCtxVar
 
     @property
-    def _store(self) -> dict[t.Hashable, t.Any]:
+    def _store(self) -> dict[Hashable, Any]:
         try:
             store = self._store_cvar.get()
         except LookupError:
@@ -88,10 +91,10 @@ class _wsgiscope(picobox.Scope):
             scope_store = store.setdefault(self, {})
         return scope_store
 
-    def set(self, key: t.Hashable, value: t.Any) -> None:
+    def set(self, key: Hashable, value: Any) -> None:
         self._store[key] = value
 
-    def get(self, key: t.Hashable) -> t.Any:
+    def get(self, key: Hashable) -> Any:
         return self._store[key]
 
 


### PR DESCRIPTION
Since introduction of `from __future__ import annotations` in the project sources, the annotations evaluations aren't happening at runtime, which means we can start using modern type annotation techniques, such as | operand instead of Union.

It also means we can completely rely on the `typing` module and drop `typing_extensions` because all imports are now under TYPE_CHECKING, and their usage in signatures are not evaluated at runtime.