### PR TITLE
Add Python 3.13, drop Python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Run lints
         run: python3 -m pip install hatch && hatch run lint:run
@@ -25,7 +25,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.8"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.10"]
+        exclude:
+          # The job hangs for some reason during tests execution. :(
+          - os: macos-latest
+            python-version: pypy-3.10
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -49,7 +53,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Run lints
         run: python3 -m pip install hatch && hatch run type:run
@@ -63,7 +67,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Run sphinx
         run: python3 -m pip install hatch && hatch run docs:run

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -381,6 +381,10 @@ Release Notes
 
 (unreleased)
 
+* Add ``Python 3.13`` support.
+
+* Drop ``Python 3.8`` support. It reached its end-of-life recently.
+
 * Add ``picobox.ext.wsgiscopes`` extensions with ``application`` and ``request``
   scopes for WSGI applications.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "picobox"
 description = "Dependency injection framework designed with Python in mind."
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = "MIT"
 authors = [{ name = "Ihor Kalnytskyi", email = "ihor@kalnytskyi.com" }]
 classifiers = [
@@ -15,11 +15,11 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
   "Topic :: Software Development :: Libraries",


### PR DESCRIPTION
Python 3.8 has reached its end of life the day Python 3.13 was released.