### PR TITLE
Bump Ruff from 0.6.8 to 0.7.*

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ scripts.run = "python -m pytest --strict-markers {args:-vv}"
 
 [tool.hatch.envs.lint]
 detached = true
-dependencies = ["ruff == 0.6.*"]
+dependencies = ["ruff == 0.7.*"]
 scripts.run = ["ruff check {args:.}", "ruff format --check --diff {args:.}"]
 
 [tool.hatch.envs.type]


### PR DESCRIPTION
Ruff 0.7 was released few days ago. Let's embrace the most lattest version. Just a reminder to myself: since Ruff lint rules change time to time, I use major version pinning to make sure CI is not going to break over night.

https://astral.sh/blog/ruff-v0.7.0