### PR TITLE
Run typos on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,15 @@ on:
     branches: [master]
 
 jobs:
+  typo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Check spelling of file.txt
+        uses: crate-ci/typos@master
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -275,7 +275,7 @@ are done with it.
     picobox provides a :class:`picobox.Stack` class to create an independent
     non overlapping stack with boxes suitable to be used in such cases.
 
-    Just create a global instance of stack (globals themeselves aren't bad),
+    Just create a global instance of stack (globals themselves aren't bad),
     and use it as you'd use picobox stacked interface:
 
     .. code:: python

--- a/src/picobox/_stack.py
+++ b/src/picobox/_stack.py
@@ -130,7 +130,7 @@ class Stack:
             this option set to ``True``.
         """
         # list.append() is a thread-safe operation in CPython, yet the safety
-        # is not guranteed by the language itself. So the lock is used here to
+        # is not guaranteed by the language itself. So the lock is used here to
         # ensure the code works properly even when running on alternative
         # implementations.
         with self._lock:
@@ -156,7 +156,7 @@ class Stack:
         :raises IndexError: If the stack is empty and there's nothing to pop.
         """
         # list.append() is a thread-safe operation in CPython, yet the safety
-        # is not guranteed by the language itself. So the lock is used here to
+        # is not guaranteed by the language itself. So the lock is used here to
         # ensure the code works properly even when running on alternative
         # implementations.
         with self._lock:


### PR DESCRIPTION
Typos[^1] is a source code spell checker with low false positive rate, designed to be run on CI. I wouldn't lie, it does sound intriguing. Let's try it and see how it goes.

[^1]: https://github.com/crate-ci/typos