### PR TITLE
Skip ASGI websocket tests on PyPy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy-3.10"]
-        exclude:
-          # The job hangs for some reason during tests execution. :(
-          - os: macos-latest
-            python-version: pypy-3.10
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/tests/ext/test_asgiscopes.py
+++ b/tests/ext/test_asgiscopes.py
@@ -1,6 +1,7 @@
 """Test ASGI scopes."""
 
 import asyncio
+import sys
 
 import async_asgi_testclient
 import pytest
@@ -97,6 +98,9 @@ def app_factory(connection_type):
 @pytest.fixture
 def client_factory(connection_type):
     """A factory that creates synchronous test client instances."""
+
+    if connection_type == "websocket" and sys.implementation.name == "pypy":
+        pytest.skip("When running on PyPy, the websocket tests sometimes hang.")
 
     def factory(app):
         return ClientFacade(app, connection_type)


### PR DESCRIPTION
When running on PyPy, the ASGI websocket tests sometimes hang. This is especially annoying on CI/CD. Most likely the issue lies either in the Starlette's TestClient implementation, or anyio it delegates to process the request in a background thread. For a time being, it's better to skip them for good.