### PR TITLE
Bump Ruff to 0.9

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,6 +2,7 @@
 
 import importlib.metadata
 
+
 # -- Project settings
 project = "Picobox"
 author = "Ihor Kalnytskyi"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,12 +35,19 @@ Bugs = "https://github.com/ikalnytskyi/picobox/issues"
 source = "vcs"
 
 [tool.hatch.envs.test]
-dependencies = ["pytest", "pytest-asyncio", "flask", "starlette", "httpx", "async-asgi-testclient"]
+dependencies = [
+  "async-asgi-testclient",
+  "flask",
+  "httpx",
+  "pytest",
+  "pytest-asyncio",
+  "starlette",
+]
 scripts.run = "python -m pytest --strict-markers {args:-vv}"
 
 [tool.hatch.envs.lint]
 detached = true
-dependencies = ["ruff == 0.7.*"]
+dependencies = ["ruff == 0.9.*"]
 scripts.run = ["ruff check {args:.}", "ruff format --check --diff {args:.}"]
 
 [tool.hatch.envs.type]
@@ -56,13 +63,43 @@ line-length = 100
 
 [tool.ruff.lint]
 select = ["ALL"]
-ignore = ["ANN", "PLR", "D107", "D203", "D213", "D401", "SIM117", "N801", "PLW2901", "PERF203", "COM812", "ISC001"]
+ignore = [
+  "ANN401",
+  "COM812",
+  "D107",
+  "D203",
+  "D213",
+  "D401",
+  "PERF203",
+  "PLR",
+  "PLW2901",
+  "SIM117",
+]
+
+[tool.ruff.lint.isort]
+lines-after-imports = 2
+
+[tool.ruff.lint.pep8-naming]
+extend-ignore-names = [
+  "_asgiscope",
+  "_flask_store_obj",
+  "_flaskscope",
+  "_wsgiscope",
+  "application",
+  "contextvars",
+  "namespacescope",
+  "noscope",
+  "request",
+  "singleton",
+  "threadlocal",
+]
 
 [tool.ruff.lint.per-file-ignores]
 "docs/*" = ["INP001"]
-"examples/*" = ["I", "D", "T20", "INP001"]
+"examples/*" = ["ANN", "I", "D", "T20", "INP001"]
 "examples/flask/wsgi.py" = ["F401", "E402"]
-"tests/*" = ["D", "S101", "ARG001", "BLE001", "INP001"]
+"tests/*" = ["ANN", "D", "S101", "ARG001", "BLE001", "INP001"]
+
 
 [tool.mypy]
 files = ["src"]

--- a/src/picobox/__init__.py
+++ b/src/picobox/__init__.py
@@ -4,18 +4,19 @@ from ._box import Box, ChainBox
 from ._scopes import Scope, contextvars, noscope, singleton, threadlocal
 from ._stack import Stack, get, pass_, pop, push, put
 
+
 __all__ = [
     "Box",
     "ChainBox",
     "Scope",
+    "Stack",
+    "contextvars",
+    "get",
+    "noscope",
+    "pass_",
+    "pop",
+    "push",
+    "put",
     "singleton",
     "threadlocal",
-    "contextvars",
-    "noscope",
-    "Stack",
-    "push",
-    "pop",
-    "put",
-    "get",
-    "pass_",
 ]

--- a/src/picobox/_box.py
+++ b/src/picobox/_box.py
@@ -9,6 +9,7 @@ import typing
 
 from . import _scopes
 
+
 if typing.TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Hashable
     from typing import Any, ParamSpec, TypeVar, Union

--- a/src/picobox/_scopes.py
+++ b/src/picobox/_scopes.py
@@ -8,6 +8,7 @@ import threading
 import typing
 import weakref
 
+
 if typing.TYPE_CHECKING:
     from collections.abc import Hashable
     from typing import Any

--- a/src/picobox/_stack.py
+++ b/src/picobox/_stack.py
@@ -8,6 +8,7 @@ import typing
 
 from ._box import Box, ChainBox, _unset
 
+
 if typing.TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Generator, Hashable
     from contextlib import AbstractContextManager

--- a/src/picobox/ext/asgiscopes.py
+++ b/src/picobox/ext/asgiscopes.py
@@ -8,6 +8,7 @@ import weakref
 
 import picobox
 
+
 if typing.TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Hashable, MutableMapping
     from typing import Any

--- a/src/picobox/ext/flaskscopes.py
+++ b/src/picobox/ext/flaskscopes.py
@@ -9,6 +9,7 @@ import flask
 
 import picobox
 
+
 if typing.TYPE_CHECKING:
     from collections.abc import Hashable
     from typing import Any

--- a/src/picobox/ext/wsgiscopes.py
+++ b/src/picobox/ext/wsgiscopes.py
@@ -8,6 +8,7 @@ import weakref
 
 import picobox
 
+
 if typing.TYPE_CHECKING:
     from collections.abc import Hashable, Iterable
     from typing import Any


### PR DESCRIPTION
The patch also makes sure that there are 2 empty lines between imports and code. A convention I got used to like. In addition to that, some of the rules are now ignored for tests only, meaning the main code base is even more covered with lint checks.